### PR TITLE
[JENKINS-36417] PoC: Integrate BuildSelector extension point

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>copyartifact</artifactId>
+            <version>1.38</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-aggregator</artifactId>
             <version>${workflow.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,8 @@
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>copyartifact</artifactId>
-            <version>1.38</version>
+            <artifactId>run-selector</artifactId>
+            <version>1.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateExecution.java
@@ -18,6 +18,8 @@ import org.jenkinsci.plugins.ewm.steps.model.ExternalWorkspace;
 import org.jenkinsci.plugins.ewm.strategies.DiskAllocationStrategy;
 import org.jenkinsci.plugins.ewm.strategies.MostUsableSpaceStrategy;
 import org.jenkinsci.plugins.runselector.context.RunSelectorPickContext;
+import org.jenkinsci.plugins.runselector.filters.NoRunFilter;
+import org.jenkinsci.plugins.runselector.filters.RunFilter;
 import org.jenkinsci.plugins.runselector.selectors.RunSelector;
 import org.jenkinsci.plugins.runselector.selectors.StatusRunSelector;
 import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
@@ -110,7 +112,8 @@ public class ExwsAllocateExecution extends AbstractSynchronousNonBlockingStepExe
 
             String jobName = envVars.expand(upstreamName);
             context.setProjectName(jobName);
-            context.setRunFilter(step.getRunFilter());
+            RunFilter runFilter = step.getRunFilter() != null ? step.getRunFilter() : new NoRunFilter();
+            context.setRunFilter(runFilter);
 
             Run<?, ?> upstreamBuild = selector.pickBuildToCopyFrom(upstreamJob, context);
 

--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateExecution.java
@@ -2,11 +2,18 @@ package org.jenkinsci.plugins.ewm.steps;
 
 import com.google.inject.Inject;
 import hudson.AbortException;
+import hudson.EnvVars;
 import hudson.FilePath;
-import hudson.model.Item;
+import hudson.model.AbstractBuild;
 import hudson.model.Job;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.plugins.copyartifact.BuildFilter;
+import hudson.plugins.copyartifact.BuildSelector;
+import hudson.plugins.copyartifact.ParametersBuildFilter;
+import hudson.plugins.copyartifact.StatusBuildSelector;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.ewm.actions.ExwsAllocateActionImpl;
 import org.jenkinsci.plugins.ewm.definitions.Disk;
@@ -18,6 +25,7 @@ import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepEx
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
 
 import static hudson.Util.isRelativePath;
@@ -31,6 +39,7 @@ import static java.lang.String.format;
 public class ExwsAllocateExecution extends AbstractSynchronousNonBlockingStepExecution<ExternalWorkspace> {
 
     private static final long serialVersionUID = 1L;
+    private static final BuildSelector DEFAULT_BUILD_SELECTOR = new StatusBuildSelector(true);
 
     @Inject(optional = true)
     private transient ExwsAllocateStep step;
@@ -76,21 +85,32 @@ public class ExwsAllocateExecution extends AbstractSynchronousNonBlockingStepExe
         } else {
             // this is the downstream job
 
+            BuildSelector selector = step.getSelector();
+            if (selector == null) {
+                listener.getLogger().println(format("No selector provided. Using the default build selector: %s", DEFAULT_BUILD_SELECTOR.getDescriptor().getDisplayName()));
+                selector = DEFAULT_BUILD_SELECTOR;
+            }
+
             if (step.getDiskPoolId() != null) {
                 listener.getLogger().println("WARNING: Both 'upstream' and 'diskPoolId' parameters were provided. " +
                         "The 'diskPoolId' parameter will be ignored. The step will allocate the workspace used by the upstream job.");
             }
 
-            Item upstreamJob = Jenkins.getActiveInstance().getItemByFullName(upstreamName);
+            Job<?, ?> upstreamJob = Jenkins.getActiveInstance().getItemByFullName(upstreamName, Job.class);
             if (upstreamJob == null) {
                 throw new AbortException(format("Can't find any upstream Jenkins job by the full name '%s'. Are you sure that this is the full project name?", upstreamName));
             }
-            Run lastStableBuild = ((Job) upstreamJob).getLastStableBuild();
-            if (lastStableBuild == null) {
-                throw new AbortException(format("'%s' doesn't have any stable build", upstreamName));
+
+            EnvVars envVars = getEnvVars();
+            String parameters = step.getParameters();
+            BuildFilter buildFilter = parameters != null ? new ParametersBuildFilter(envVars.expand(parameters)) : new BuildFilter();
+
+            Run<?, ?> upstreamBuild = selector.getBuild(upstreamJob, envVars, buildFilter, run);
+            if (upstreamBuild == null) {
+                throw new AbortException(format("Unable to find a build within upstream job '%s'", upstreamName));
             }
 
-            ExwsAllocateActionImpl allocateAction = lastStableBuild.getAction(ExwsAllocateActionImpl.class);
+            ExwsAllocateActionImpl allocateAction = upstreamBuild.getAction(ExwsAllocateActionImpl.class);
             if (allocateAction == null) {
                 String message = format("The upstream job '%s' must have at least one stable build with a call to the " +
                         "exwsAllocate step in order to have a workspace usable by this job.", upstreamName);
@@ -119,6 +139,28 @@ public class ExwsAllocateExecution extends AbstractSynchronousNonBlockingStepExe
         listener.getLogger().println(format("The path on Disk is: %s", exws.getPathOnDisk()));
 
         return exws;
+    }
+
+    /**
+     * Gets the environment variables based on the current run.
+     *
+     * @return the {@link EnvVars} for the current run
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    private EnvVars getEnvVars() throws IOException, InterruptedException {
+        EnvVars envVars = run.getEnvironment(listener);
+        if (run instanceof AbstractBuild) {
+            envVars.overrideAll(((AbstractBuild<?, ?>) run).getBuildVariables());
+        } else {
+            for (ParametersAction pa : run.getActions(ParametersAction.class)) {
+                for (ParameterValue pv : pa.getParameters()) {
+                    pv.buildEnvironment(run, envVars);
+                }
+            }
+        }
+
+        return envVars;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.ewm.steps;
 
 import hudson.Extension;
+import hudson.plugins.copyartifact.BuildSelector;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.ewm.Messages;
 import org.jenkinsci.plugins.ewm.definitions.DiskPool;
@@ -27,6 +28,8 @@ public final class ExwsAllocateStep extends AbstractStepImpl {
 
     private final String diskPoolId;
     private String upstream;
+    private BuildSelector selector;
+    private String parameters;
 
     @DataBoundConstructor
     public ExwsAllocateStep(String diskPoolId) {
@@ -46,6 +49,26 @@ public final class ExwsAllocateStep extends AbstractStepImpl {
     @DataBoundSetter
     public void setUpstream(String upstream) {
         this.upstream = fixEmptyAndTrim(upstream);
+    }
+
+    @CheckForNull
+    public BuildSelector getSelector() {
+        return selector;
+    }
+
+    @DataBoundSetter
+    public void setSelector(BuildSelector selector) {
+        this.selector = selector;
+    }
+
+    @CheckForNull
+    public String getParameters() {
+        return parameters;
+    }
+
+    @DataBoundSetter
+    public void setParameters(String parameters) {
+        this.parameters = parameters;
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep.java
@@ -1,10 +1,12 @@
 package org.jenkinsci.plugins.ewm.steps;
 
 import hudson.Extension;
-import hudson.plugins.copyartifact.BuildSelector;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.ewm.Messages;
 import org.jenkinsci.plugins.ewm.definitions.DiskPool;
+import org.jenkinsci.plugins.runselector.filters.RunFilter;
+import org.jenkinsci.plugins.runselector.filters.RunFilterDescriptor;
+import org.jenkinsci.plugins.runselector.selectors.RunSelector;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -28,8 +30,9 @@ public final class ExwsAllocateStep extends AbstractStepImpl {
 
     private final String diskPoolId;
     private String upstream;
-    private BuildSelector selector;
-    private String parameters;
+    private RunSelector selector;
+    private RunFilter runFilter;
+    private boolean verbose;
 
     @DataBoundConstructor
     public ExwsAllocateStep(String diskPoolId) {
@@ -52,23 +55,32 @@ public final class ExwsAllocateStep extends AbstractStepImpl {
     }
 
     @CheckForNull
-    public BuildSelector getSelector() {
+    public RunSelector getSelector() {
         return selector;
     }
 
     @DataBoundSetter
-    public void setSelector(BuildSelector selector) {
+    public void setSelector(RunSelector selector) {
         this.selector = selector;
     }
 
     @CheckForNull
-    public String getParameters() {
-        return parameters;
+    public RunFilter getRunFilter() {
+        return runFilter;
     }
 
     @DataBoundSetter
-    public void setParameters(String parameters) {
-        this.parameters = parameters;
+    public void setRunFilter(RunFilter runFilter) {
+        this.runFilter = runFilter;
+    }
+
+    public boolean isVerbose() {
+        return verbose;
+    }
+
+    @DataBoundSetter
+    public void setVerbose(boolean verbose) {
+        this.verbose = verbose;
     }
 
     @Override
@@ -91,6 +103,10 @@ public final class ExwsAllocateStep extends AbstractStepImpl {
             diskPools = req.bindJSONToList(DiskPool.class, formData.get("diskPools"));
             save();
             return super.configure(req, formData);
+        }
+
+        public List<RunFilterDescriptor> getRunFilterDescriptorList() {
+            return RunFilter.allWithNoRunFilter();
         }
 
         @Nonnull

--- a/src/main/resources/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep/config.jelly
@@ -6,8 +6,10 @@
     <f:entry title="Upstream" field="upstream">
         <f:textbox/>
     </f:entry>
-    <f:dropdownDescriptorSelector title="${%Which build}" field="selector"/>
-    <f:entry title="${%Parameter filters}" field="parameters">
-        <f:textbox/>
+    <f:entry field="verbose">
+        <f:checkbox title="${%Debug output}" />
     </f:entry>
+    <f:dropdownDescriptorSelector title="${%Which build}" field="selector"/>
+    <f:dropdownDescriptorSelector title="${%Run filter}" field="runFilter"
+                                  descriptors="${descriptor.runFilterDescriptorList}"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep/config.jelly
@@ -4,6 +4,10 @@
         <f:textbox/>
     </f:entry>
     <f:entry title="Upstream" field="upstream">
-        <f:textbox />
+        <f:textbox/>
+    </f:entry>
+    <f:dropdownDescriptorSelector title="${%Which build}" field="selector"/>
+    <f:entry title="${%Parameter filters}" field="parameters">
+        <f:textbox/>
     </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep/help-parameters.html
+++ b/src/main/resources/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep/help-parameters.html
@@ -1,0 +1,10 @@
+<div>
+    <p>
+        Jobs may be filtered to select only builds matching particular parameters or other build variables.
+        Use <kbd>PARAM=VALUE,...</kbd> to list the parameter filter
+    </p>
+    <p>
+        For example, <kbd>FOO=bar,BAZ=true</kbd> examines only builds that ran with parameter
+        <kbd>FOO</kbd> set to <kbd>bar</kbd> and the checkbox for <kbd>BAZ</kbd> was checked.
+    </p>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep/help-runFilter.html
+++ b/src/main/resources/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep/help-runFilter.html
@@ -1,0 +1,3 @@
+<div>
+  Additional conditions to select builds.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep/help-selector.html
+++ b/src/main/resources/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep/help-selector.html
@@ -1,0 +1,9 @@
+<div>
+    <p>
+        Strategy for selecting the upstream build.
+        e.g. latest successful build, latest stable build, specific build number, etc.
+    </p>
+    <p>
+        The selection strategies are the ones used by the Copy Artifact plugin.
+    </p>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep/help-selector.html
+++ b/src/main/resources/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep/help-selector.html
@@ -4,6 +4,6 @@
         e.g. latest successful build, latest stable build, specific build number, etc.
     </p>
     <p>
-        The selection strategies are the ones used by the Copy Artifact plugin.
+        The selection strategies are the inherited from Run Selector plugin.
     </p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep/help-verbose.html
+++ b/src/main/resources/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep/help-verbose.html
@@ -1,0 +1,4 @@
+<div>
+Outputs detailed logs to the build console.
+Used for the diagnostic purpose.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStepTest.java
@@ -153,7 +153,7 @@ public class ExwsAllocateStepTest {
 
         j.assertBuildStatus(FAILURE, upstreamRun);
         j.assertBuildStatus(FAILURE, downstreamRun);
-        j.assertLogContains(format("'%s' doesn't have any stable build", upstreamName), downstreamRun);
+        j.assertLogContains(format("Unable to find a build within upstream job '%s'", upstreamName), downstreamRun);
     }
 
     @Test


### PR DESCRIPTION
Related to issue [[JENKINS-36417]](https://issues.jenkins-ci.org/browse/JENKINS-36417)

Summary of this pull request:
 - Allow the user to specify multiple build selection strategies by integrating the BuildSelector extension point from Copy Artifact plugin.

A few possible selection strategies:

1. Specific build number from the upstream job
   ```groovy
   def exwsWorkspace = exwsAllocate upstream: 'upstream-full-name',
selector: [$class: 'SpecificRunSelector', buildNumber: '20']
   ```

1. Last stable build from the upstream job
   ```groovy
   def exwsWorkspace = exwsAllocate upstream: 'upstream-full-name', 
selector: [$class: 'StatusRunSelector', buildStatus: 'Stable']
   ```

1. The upstream build that triggered the downstream
 - Upstream job

   ```groovy
   // ...
   build ('full-downstream-name')
   ``` 
 - Downstream job

   ```groovy
   def exwsWorkspace = exwsAllocate upstream: 'upstream-full-name', 
selector: [$class: 'TriggeringRunSelector']
   ```

CC @martinda @oleg-nenashev 