### PR TITLE
PoC: Light run selector vs 'RunSelector' wrapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
             <artifactId>workflow-step-api</artifactId>
             <version>${workflow.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <version>${workflow.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>run-selector-api</artifactId>
+            <version>0.1.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-aggregator</artifactId>
             <version>${workflow.version}</version>

--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateExecution.java
@@ -3,11 +3,8 @@ package org.jenkinsci.plugins.ewm.steps;
 import com.google.inject.Inject;
 import hudson.AbortException;
 import hudson.FilePath;
-import hudson.model.Item;
-import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.ewm.actions.ExwsAllocateActionImpl;
 import org.jenkinsci.plugins.ewm.definitions.Disk;
 import org.jenkinsci.plugins.ewm.definitions.DiskPool;
@@ -44,7 +41,7 @@ public class ExwsAllocateExecution extends AbstractSynchronousNonBlockingStepExe
     protected ExternalWorkspace run() throws Exception {
         ExternalWorkspace exws;
         String upstreamName = step.getUpstream();
-        if (upstreamName == null) {
+        if (step.getSelectedRun() == null) {
             // this is the upstream job
 
             String diskPoolId = step.getDiskPoolId();
@@ -77,21 +74,27 @@ public class ExwsAllocateExecution extends AbstractSynchronousNonBlockingStepExe
             // this is the downstream job
 
             if (step.getDiskPoolId() != null) {
+                // TODO change error message
                 listener.getLogger().println("WARNING: Both 'upstream' and 'diskPoolId' parameters were provided. " +
                         "The 'diskPoolId' parameter will be ignored. The step will allocate the workspace used by the upstream job.");
             }
 
-            Item upstreamJob = Jenkins.getActiveInstance().getItemByFullName(upstreamName);
-            if (upstreamJob == null) {
-                throw new AbortException(format("Can't find any upstream Jenkins job by the full name '%s'. Are you sure that this is the full project name?", upstreamName));
-            }
-            Run lastStableBuild = ((Job) upstreamJob).getLastStableBuild();
+            // TODO remove this
+//            Item upstreamJob = Jenkins.getActiveInstance().getItemByFullName(upstreamName);
+//            if (upstreamJob == null) {
+//                throw new AbortException(format("Can't find any upstream Jenkins job by the full name '%s'. Are you sure that this is the full project name?", upstreamName));
+//            }
+
+            // TODO - rename variables
+            Run lastStableBuild = step.getSelectedRun().getRawBuild(); //((Job) upstreamJob).getLastStableBuild();
             if (lastStableBuild == null) {
+                // TODO rename err message
                 throw new AbortException(format("'%s' doesn't have any stable build", upstreamName));
             }
 
             ExwsAllocateActionImpl allocateAction = lastStableBuild.getAction(ExwsAllocateActionImpl.class);
             if (allocateAction == null) {
+                // TODO change err message
                 String message = format("The upstream job '%s' must have at least one stable build with a call to the " +
                         "exwsAllocate step in order to have a workspace usable by this job.", upstreamName);
                 throw new AbortException(message);

--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep.java
@@ -6,6 +6,7 @@ import org.jenkinsci.plugins.ewm.Messages;
 import org.jenkinsci.plugins.ewm.definitions.DiskPool;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -27,6 +28,16 @@ public final class ExwsAllocateStep extends AbstractStepImpl {
 
     private final String diskPoolId;
     private String upstream;
+    private RunWrapper selectedRun;
+
+    public RunWrapper getSelectedRun() {
+        return selectedRun;
+    }
+
+    @DataBoundSetter
+    public void setSelectedRun(RunWrapper selectedRun) {
+        this.selectedRun = selectedRun;
+    }
 
     @DataBoundConstructor
     public ExwsAllocateStep(String diskPoolId) {

--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/RunSelectorExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/RunSelectorExecution.java
@@ -1,0 +1,73 @@
+package org.jenkinsci.plugins.ewm.steps;
+
+import com.google.inject.Inject;
+import hudson.AbortException;
+import hudson.model.Job;
+import hudson.model.PermalinkProjectAction;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper;
+
+import static java.lang.String.format;
+
+/**
+ * @author Alexandru Somai
+ */
+public class RunSelectorExecution extends AbstractSynchronousNonBlockingStepExecution<RunWrapper> {
+
+    @Inject
+    private transient RunSelectorStep step;
+
+    @StepContextParameter
+    private transient Run<?, ?> run;
+    @StepContextParameter
+    private transient TaskListener listener;
+
+    @Override
+    protected RunWrapper run() throws Exception {
+
+        // TODO more detailed error messages
+
+        String jobName = step.getJobName();
+        if (jobName == null) {
+            throw new AbortException("'jobName' parameter not set!");
+        }
+
+        Job<?, ?> upstreamJob = Jenkins.getActiveInstance().getItem(jobName, run.getParent(), Job.class);
+        if (upstreamJob == null) {
+            throw new AbortException(format("Can't find upstream project named: '%s'", jobName));
+        }
+
+        String permalink = step.getPermalink();
+        if (permalink != null) {
+            PermalinkProjectAction.Permalink p = upstreamJob.getPermalinks().get(permalink);
+            if (p == null) {
+                throw new AbortException(format("Can't find run in the upstream job '%s' identified by '%s'", upstreamJob, permalink));
+            }
+            Run<?, ?> upstreamRun = p.resolve(upstreamJob);
+            if (upstreamRun == null) {
+                throw new AbortException("Can't find run by permalink!");
+            }
+            return new RunWrapper(upstreamRun, false);
+        }
+
+        Integer buildNumber = step.getBuildNumber();
+        if (buildNumber != null) {
+            Run<?, ?> upstreamRun = upstreamJob.getBuildByNumber(buildNumber);
+            if (upstreamRun == null) {
+                throw new AbortException("Can't find run by build number!");
+            }
+            return new RunWrapper(upstreamRun, false);
+        }
+
+        listener.getLogger().println("Fallback to searching for the last stable build");
+        Run<?, ?> upstreamRun = upstreamJob.getLastStableBuild();
+        if (upstreamRun == null) {
+            throw new AbortException("Can't find last stable build!");
+        }
+        return new RunWrapper(upstreamRun, false);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/RunSelectorStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/RunSelectorStep.java
@@ -1,0 +1,67 @@
+package org.jenkinsci.plugins.ewm.steps;
+
+import hudson.Extension;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.CheckForNull;
+
+/**
+ * @author Alexandru Somai
+ */
+public class RunSelectorStep extends AbstractStepImpl {
+
+    @CheckForNull
+    private final String jobName;
+    @CheckForNull
+    private String permalink;
+    @CheckForNull
+    private Integer buildNumber;
+
+    // TODO add a config file for this!
+
+    @DataBoundConstructor
+    public RunSelectorStep(String jobName) {
+        this.jobName = jobName;
+    }
+
+    @CheckForNull
+    public String getJobName() {
+        return jobName;
+    }
+
+    @CheckForNull
+    public String getPermalink() {
+        return permalink;
+    }
+
+    @DataBoundSetter
+    public void setPermalink(String permalink) {
+        this.permalink = permalink;
+    }
+
+    @CheckForNull
+    public Integer getBuildNumber() {
+        return buildNumber;
+    }
+
+    @DataBoundSetter
+    public void setBuildNumber(Integer buildNumber) {
+        this.buildNumber = buildNumber;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+        public DescriptorImpl() {
+            super(RunSelectorExecution.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "runSelector";
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/RunSelectorWrapperExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/RunSelectorWrapperExecution.java
@@ -1,0 +1,60 @@
+package org.jenkinsci.plugins.ewm.steps;
+
+import com.google.inject.Inject;
+import hudson.AbortException;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.runselector.RunSelector;
+import org.jenkinsci.plugins.runselector.context.RunSelectorContext;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper;
+
+import static java.lang.String.format;
+
+/**
+ * @author Alexandru Somai
+ */
+public class RunSelectorWrapperExecution extends AbstractSynchronousNonBlockingStepExecution<RunWrapper> {
+
+    @Inject
+    private transient RunSelectorWrapperStep step;
+
+    @StepContextParameter
+    private transient Run<?, ?> run;
+    @StepContextParameter
+    private transient TaskListener listener;
+
+    @Override
+    protected RunWrapper run() throws Exception {
+
+        // TODO more detailed error messages
+
+        String jobName = step.getJobName();
+        if (jobName == null) {
+            throw new AbortException("'jobName' parameter not set!");
+        }
+
+        Job<?, ?> upstreamJob = Jenkins.getActiveInstance().getItem(jobName, run.getParent(), Job.class);
+        if (upstreamJob == null) {
+            throw new AbortException(format("Can't find upstream project named: '%s'", jobName));
+        }
+
+        RunSelector selector = step.getSelector();
+        if (selector == null) {
+            throw new AbortException("Run Selector not set!");
+        }
+
+        RunSelectorContext context = new RunSelectorContext(Jenkins.getActiveInstance(), run, listener);
+        context.setVerbose(true);
+
+        Run<?, ?> upstreamRun = selector.select(upstreamJob, context);
+        if (upstreamRun == null) {
+            throw new AbortException("No upstream run found!");
+        }
+
+        return new RunWrapper(upstreamRun, false);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/RunSelectorWrapperStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/RunSelectorWrapperStep.java
@@ -1,0 +1,55 @@
+package org.jenkinsci.plugins.ewm.steps;
+
+import hudson.Extension;
+import org.jenkinsci.plugins.runselector.RunSelector;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.CheckForNull;
+
+/**
+ * @author Alexandru Somai
+ */
+public class RunSelectorWrapperStep extends AbstractStepImpl {
+
+    @CheckForNull
+    private final String jobName;
+    @CheckForNull
+    private RunSelector selector;
+
+    // TODO add a config file for this!
+
+    @DataBoundConstructor
+    public RunSelectorWrapperStep(String jobName) {
+        this.jobName = jobName;
+    }
+
+    @CheckForNull
+    public String getJobName() {
+        return jobName;
+    }
+
+    public RunSelector getSelector() {
+        return selector;
+    }
+
+    @DataBoundSetter
+    public void setSelector(RunSelector selector) {
+        this.selector = selector;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+        public DescriptorImpl() {
+            super(RunSelectorWrapperExecution.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "runSelectorWrapper";
+        }
+    }
+}


### PR DESCRIPTION
This PR is a PoC to show the differences between a light `runSelector` step vs. a step that is based on the [Run Selector API plugin](https://github.com/jenkinsci/run-selector-plugin).

Examples
-
**USE CASE 1. Select the last stable run from the upstream job**

 a. First option, using the `runSelector` step
```groovy
def run = runSelector jobName: 'upstream-name', permalink: 'lastStableBuild'
def extWorkspace = exwsAllocate selectedRun: run
// ... 
```
 b. Second option, using a step that is based on the `selector` parameter.
The selector in this case is `PermalinkRunSelector` (or `StatusRunSelector`)

```groovy
def run = runSelectorWrapper jobName: 'upstream-name', 
selector: [$class: 'PermalinkRunSelector', id: 'lastStableBuild'] 
// or can be used selector: [$class: 'StatusRunSelector', buildStatus: 'stable']
def extWorkspace = exwsAllocate selectedRun: run
// ... 
```

**USE CASE 2. Select a specific build number from the upstream job**
 a. First option, using the `runSelector` step
```groovy
def run = runSelector jobName: 'upstream-name', buildNumber: 20
def extWorkspace = exwsAllocate selectedRun: run
// ... 
```
 b. Second option, using a step that is based on the `selector` parameter. 
The selector in this case is `SpecificRunSelector`

```groovy
def run = runSelectorWrapper jobName: 'upstream-name', 
selector: [$class: 'SpecificRunSelector', buildNumber: '20'] 

def extWorkspace = exwsAllocate selectedRun: run
// ... 
```

**USE CASE 3. The downstream job was triggered by the upstream job**
 a. First option, using the `runSelector` step. 
The upstream job **must pass** as a parameter the _env.BUILD_NUMBER_

**Upstream job**
```groovy
// ...
build job: 'downstream-name', 
parameters: [[$class: 'StringParameterValue', name: 'UPSTREAM_BUILD_NUMBER', value: env.BUILD_NUMBER]]
```
**Downstream job**
```groovy
def run = runSelector jobName: 'upstream-name', buildNumber: UPSTREAM_BUILD_NUMBER
def extWorkspace = exwsAllocate selectedRun: run
// ... 
```

 b. Second option, using a step that is based on the `selector` parameter. 
The selector in this case is `TriggeringRunSelector`.
The upstream job **does not have** to pass additional parameters.

**Upstream job**
```groovy
// ...
build ('downstream-name')
```
**Downstream job**
```groovy
def run = runSelectorWrapper jobName: 'upstream-name', 
selector: [$class: 'TriggeringRunSelector'] 

def extWorkspace = exwsAllocate selectedRun: run
// ... 
```


Opinions @oleg-nenashev @martinda?