### PR TITLE
[JENKINS-36962] Integrate Job Restrictions plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
             <version>${workflow.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.synopsys.arc.jenkinsci.plugins</groupId>
+            <artifactId>job-restrictions</artifactId>
+            <version>0.4</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
             <version>${workflow.version}</version>

--- a/src/main/java/org/jenkinsci/plugins/ewm/definitions/DiskPool.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/definitions/DiskPool.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.ewm.definitions;
 
+import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.restrictions.JobRestriction;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
@@ -9,6 +10,7 @@ import org.jenkinsci.plugins.ewm.utils.FormValidationUtil;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
 import javax.annotation.CheckForNull;
@@ -32,6 +34,9 @@ public class DiskPool implements Describable<DiskPool> {
     private final String description;
     private final String workspaceTemplate;
     private final List<Disk> disks;
+
+    @CheckForNull
+    private JobRestriction restriction;
 
     @DataBoundConstructor
     public DiskPool(String diskPoolId, String displayName, String description, String workspaceTemplate, List<Disk> disks) {
@@ -70,6 +75,16 @@ public class DiskPool implements Describable<DiskPool> {
     @Nonnull
     public List<Disk> getDisks() {
         return disks;
+    }
+
+    @CheckForNull
+    public JobRestriction getRestriction() {
+        return restriction;
+    }
+
+    @DataBoundSetter
+    public void setRestriction(JobRestriction restriction) {
+        this.restriction = restriction;
     }
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/ewm/definitions/DiskPool.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/definitions/DiskPool.java
@@ -10,7 +10,6 @@ import org.jenkinsci.plugins.ewm.utils.FormValidationUtil;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
 import javax.annotation.CheckForNull;
@@ -33,17 +32,17 @@ public class DiskPool implements Describable<DiskPool> {
     private final String displayName;
     private final String description;
     private final String workspaceTemplate;
+    private final JobRestriction restriction;
     private final List<Disk> disks;
 
-    @CheckForNull
-    private JobRestriction restriction;
-
     @DataBoundConstructor
-    public DiskPool(String diskPoolId, String displayName, String description, String workspaceTemplate, List<Disk> disks) {
+    public DiskPool(String diskPoolId, String displayName, String description,
+                    String workspaceTemplate, JobRestriction restriction, List<Disk> disks) {
         this.diskPoolId = fixEmptyAndTrim(diskPoolId);
         this.displayName = fixEmptyAndTrim(displayName);
         this.description = fixEmptyAndTrim(description);
         this.workspaceTemplate = fixEmptyAndTrim(workspaceTemplate);
+        this.restriction = restriction == null ? JobRestriction.DEFAULT : restriction;
         this.disks = fixNull(disks);
     }
 
@@ -73,18 +72,13 @@ public class DiskPool implements Describable<DiskPool> {
     }
 
     @Nonnull
-    public List<Disk> getDisks() {
-        return disks;
-    }
-
-    @CheckForNull
     public JobRestriction getRestriction() {
         return restriction;
     }
 
-    @DataBoundSetter
-    public void setRestriction(JobRestriction restriction) {
-        this.restriction = restriction;
+    @Nonnull
+    public List<Disk> getDisks() {
+        return disks;
     }
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateExecution.java
@@ -121,7 +121,7 @@ public class ExwsAllocateExecution extends AbstractSynchronousNonBlockingStepExe
 
         JobRestriction restriction = diskPool.getRestriction();
         if (!diskPool.getRestriction().canTake(run)) {
-            String message = format("Disk Pool ID: '%s' is not accessible due to the applied Disk Pool restriction: %s", diskPoolId, restriction.getDescriptor().getDisplayName());
+            String message = format("Disk Pool identified by '%s' is not accessible due to the applied Disk Pool restriction: %s", diskPoolId, restriction.getDescriptor().getDisplayName());
             throw new AbortException(message);
         }
 

--- a/src/main/resources/org/jenkinsci/plugins/ewm/definitions/DiskPool/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ewm/definitions/DiskPool/config.jelly
@@ -12,6 +12,8 @@
     <f:entry title="${%Workspace path template}" field="workspaceTemplate">
         <f:textbox/>
     </f:entry>
+    <f:dropdownDescriptorSelector title="Disk Pool Restriction" field="restriction"
+                                  default="${descriptor.defaultSettingsProvider}"/>
     <f:entry>
         <f:repeatableProperty field="disks" add="${%Add Disk}" header="${%Disk}"/>
     </f:entry>

--- a/src/test/java/org/jenkinsci/plugins/ewm/steps/CustomWorkspaceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/steps/CustomWorkspaceTest.java
@@ -56,7 +56,7 @@ public class CustomWorkspaceTest {
     @Before
     public void setUp() throws IOException {
         Disk disk = new Disk(DISK_ID_ONE, null, "mount", null);
-        DiskPool diskPool = new DiskPool(DISK_POOL_ID, null, null, null, Collections.singletonList(disk));
+        DiskPool diskPool = new DiskPool(DISK_POOL_ID, null, null, null, null, Collections.singletonList(disk));
         setUpDiskPools(j.jenkins, Collections.singletonList(diskPool));
 
         tmpFolder = tmp.newFolder();
@@ -188,7 +188,7 @@ public class CustomWorkspaceTest {
 
     private static void setGlobalWorkspaceTemplate(String template) {
         Disk disk = new Disk(DISK_ID_ONE, null, "mount", null);
-        DiskPool diskPool = new DiskPool(DISK_POOL_ID, null, null, template, Collections.singletonList(disk));
+        DiskPool diskPool = new DiskPool(DISK_POOL_ID, null, null, template, null, Collections.singletonList(disk));
         setUpDiskPools(j.jenkins, Collections.singletonList(diskPool));
     }
 

--- a/src/test/java/org/jenkinsci/plugins/ewm/steps/DiskPoolRestrictionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/steps/DiskPoolRestrictionTest.java
@@ -1,0 +1,205 @@
+package org.jenkinsci.plugins.ewm.steps;
+
+import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.restrictions.JobRestriction;
+import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.restrictions.job.RegexNameRestriction;
+import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.restrictions.job.StartedByMemberOfGroupRestriction;
+import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.restrictions.job.StartedByUserRestriction;
+import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.util.GroupSelector;
+import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.util.UserSelector;
+import hudson.model.Cause;
+import hudson.model.CauseAction;
+import hudson.model.Result;
+import org.acegisecurity.Authentication;
+import org.acegisecurity.context.SecurityContextHolder;
+import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
+import org.jenkinsci.plugins.ewm.definitions.Disk;
+import org.jenkinsci.plugins.ewm.definitions.DiskPool;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Collections;
+import java.util.concurrent.Future;
+
+import static java.lang.String.format;
+import static java.util.Collections.singletonList;
+import static org.apache.commons.lang.RandomStringUtils.randomAlphanumeric;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.jenkinsci.plugins.ewm.TestUtil.DISK_ID_ONE;
+import static org.jenkinsci.plugins.ewm.TestUtil.DISK_POOL_ID;
+import static org.jenkinsci.plugins.ewm.TestUtil.setUpDiskPools;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the Disk Pool restriction feature.
+ *
+ * @author Alexandru Somai
+ */
+public class DiskPoolRestrictionTest {
+
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+
+    @ClassRule
+    public static BuildWatcher watcher = new BuildWatcher();
+
+    @After
+    public void tearDown() {
+        setUpDiskPools(j.jenkins, Collections.<DiskPool>emptyList());
+        SecurityContextHolder.getContext().setAuthentication(null);
+    }
+
+    @Test
+    public void allowedUser() throws Exception {
+        String userId = "foobar";
+        UserSelector selector = new UserSelector(userId);
+        JobRestriction restriction = new StartedByUserRestriction(singletonList(selector), false, false, false);
+        setUpDiskPoolRestriction(restriction);
+
+        authenticate(userId);
+        WorkflowRun run = createWorkflowJobAndRun();
+
+        j.assertBuildStatusSuccess(run);
+        j.assertLogContains(format("Selected Disk ID '%s' from the Disk Pool ID '%s'", DISK_ID_ONE, DISK_POOL_ID), run);
+    }
+
+    @Test
+    public void notAllowedUser() throws Exception {
+        UserSelector selector = new UserSelector("userONE");
+        JobRestriction restriction = new StartedByUserRestriction(singletonList(selector), false, false, false);
+        setUpDiskPoolRestriction(restriction);
+
+        authenticate("userTWO");
+        WorkflowRun run = createWorkflowJobAndRun();
+
+        j.assertBuildStatus(Result.FAILURE, run);
+        j.assertLogContains(format("Disk Pool identified by '%s' is not accessible due to the applied Disk Pool restriction: Started By User", DISK_POOL_ID), run);
+    }
+
+    @Test
+    public void allowedAnonymousUser() throws Exception {
+        JobRestriction restriction = new StartedByUserRestriction(Collections.<UserSelector>emptyList(), false, false, true);
+        setUpDiskPoolRestriction(restriction);
+
+        SecurityContextHolder.getContext().setAuthentication(null);
+        WorkflowRun run = createWorkflowJobAndRun();
+
+        j.assertBuildStatusSuccess(run);
+        j.assertLogContains(format("Selected Disk ID '%s' from the Disk Pool ID '%s'", DISK_ID_ONE, DISK_POOL_ID), run);
+    }
+
+    @Test
+    public void downstreamJobTriggerByRestrictedUser() throws Exception {
+        String allowedUsername = "foo";
+        UserSelector selector = new UserSelector(allowedUsername);
+        JobRestriction restriction = new StartedByUserRestriction(singletonList(selector), false, false, false);
+        setUpDiskPoolRestriction(restriction);
+
+        authenticate(allowedUsername);
+        WorkflowRun upstreamRun = createWorkflowJobAndRun();
+
+        j.assertBuildStatusSuccess(upstreamRun);
+        j.assertLogContains(format("Selected Disk ID '%s' from the Disk Pool ID '%s'", DISK_ID_ONE, DISK_POOL_ID), upstreamRun);
+
+        String notAllowedUsername = "bar";
+        authenticate(notAllowedUsername);
+
+        WorkflowJob downstreamJob = j.jenkins.createProject(WorkflowJob.class, randomAlphanumeric(7));
+        downstreamJob.setDefinition(new CpsFlowDefinition(format("" +
+                "def run = runSelector '%s' \n" +
+                "exwsAllocate selectedRun: run", upstreamRun.getParent().getFullName())));
+        WorkflowRun downstreamRun = downstreamJob.scheduleBuild2(0, new CauseAction(new Cause.UserIdCause())).get();
+
+        j.assertBuildStatus(Result.FAILURE, downstreamRun);
+        j.assertLogContains(format("Disk Pool identified by '%s' is not accessible due to the applied Disk Pool restriction: Started By User", DISK_POOL_ID), downstreamRun);
+    }
+
+    @Test
+    public void allowedGroup() throws Exception {
+        String username = "foobar";
+        String group = "allowed";
+
+        GroupSelector groupSelector = new GroupSelector(group);
+        JobRestriction restriction = new StartedByMemberOfGroupRestriction(singletonList(groupSelector), false);
+        setUpDiskPoolRestriction(restriction);
+
+        JenkinsRule.DummySecurityRealm securityRealm = j.createDummySecurityRealm();
+        securityRealm.addGroups(username, group);
+        j.jenkins.setSecurityRealm(securityRealm);
+
+        authenticate(username);
+        WorkflowRun run = createWorkflowJobAndRun();
+
+        j.assertBuildStatusSuccess(run);
+        j.assertLogContains(format("Selected Disk ID '%s' from the Disk Pool ID '%s'", DISK_ID_ONE, DISK_POOL_ID), run);
+    }
+
+    @Test
+    public void notAllowedGroup() throws Exception {
+        String username = "foobar";
+        String group = "allowed";
+
+        GroupSelector groupSelector = new GroupSelector("not-allowed-group");
+        JobRestriction restriction = new StartedByMemberOfGroupRestriction(singletonList(groupSelector), false);
+        setUpDiskPoolRestriction(restriction);
+
+        JenkinsRule.DummySecurityRealm securityRealm = j.createDummySecurityRealm();
+        securityRealm.addGroups(username, group);
+        j.jenkins.setSecurityRealm(securityRealm);
+
+        authenticate(username);
+        WorkflowRun run = createWorkflowJobAndRun();
+
+        j.assertBuildStatus(Result.FAILURE, run);
+        j.assertLogContains(format("Disk Pool identified by '%s' is not accessible due to the applied Disk Pool restriction: Started By member of group", DISK_POOL_ID), run);
+    }
+
+    @Test
+    public void allowedJobRegexName() throws Exception {
+        setUpDiskPoolRestriction(new RegexNameRestriction("test-.*", false));
+
+        WorkflowRun run = createWorkflowJobAndRun("test-workflow");
+
+        j.assertBuildStatusSuccess(run);
+        j.assertLogContains(format("Selected Disk ID '%s' from the Disk Pool ID '%s'", DISK_ID_ONE, DISK_POOL_ID), run);
+    }
+
+    @Test
+    public void notAllowedJobRegexName() throws Exception {
+        setUpDiskPoolRestriction(new RegexNameRestriction("does not match", false));
+
+        WorkflowRun run = createWorkflowJobAndRun("foobar");
+
+        j.assertBuildStatus(Result.FAILURE, run);
+        j.assertLogContains(format("Disk Pool identified by '%s' is not accessible due to the applied Disk Pool restriction: Regular Expression (Job Name)", DISK_POOL_ID), run);
+    }
+
+    private static void setUpDiskPoolRestriction(JobRestriction restriction) {
+        Disk disk = new Disk(DISK_ID_ONE, null, "any", null);
+        DiskPool diskPool = new DiskPool(DISK_POOL_ID, null, null, null, restriction, singletonList(disk));
+        setUpDiskPools(j.jenkins, singletonList(diskPool));
+    }
+
+    private static void authenticate(String principal) {
+        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "pass");
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private static WorkflowRun createWorkflowJobAndRun() throws Exception {
+        return createWorkflowJobAndRun(randomAlphanumeric(7));
+    }
+
+    private static WorkflowRun createWorkflowJobAndRun(String jobName) throws Exception {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, jobName);
+        job.setDefinition(new CpsFlowDefinition(format("exwsAllocate diskPoolId: '%s'", DISK_POOL_ID)));
+        Future<WorkflowRun> runFuture = job.scheduleBuild2(0, new CauseAction(new Cause.UserIdCause()));
+        assertThat(runFuture, notNullValue());
+
+        return runFuture.get();
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStepTest.java
@@ -182,8 +182,8 @@ public class ExwsAllocateStepTest {
     @Test
     public void upstreamJobRegisteredMultipleActions() throws Exception {
         Disk disk = new Disk(DISK_ID_ONE, "name", "mount", "path");
-        DiskPool diskPool1 = new DiskPool("id1", "name", "desc", null, Collections.singletonList(disk));
-        DiskPool diskPool2 = new DiskPool("id2", "name", "desc", null, Collections.singletonList(disk));
+        DiskPool diskPool1 = new DiskPool("id1", "name", "desc", null, null, Collections.singletonList(disk));
+        DiskPool diskPool2 = new DiskPool("id2", "name", "desc", null, null, Collections.singletonList(disk));
         setUpDiskPools(j.jenkins, Arrays.asList(diskPool1, diskPool2));
 
         upstreamRun = createWorkflowJobAndRun(format("" +
@@ -201,7 +201,7 @@ public class ExwsAllocateStepTest {
     }
 
     private void setUpDiskPool(Disk... disks) {
-        DiskPool diskPool = new DiskPool(DISK_POOL_ID, "name", "desc", null, Arrays.asList(disks));
+        DiskPool diskPool = new DiskPool(DISK_POOL_ID, "name", "desc", null, null, Arrays.asList(disks));
         setUpDiskPools(j.jenkins, Collections.singletonList(diskPool));
     }
 

--- a/src/test/java/org/jenkinsci/plugins/ewm/steps/ExwsStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/steps/ExwsStepTest.java
@@ -72,7 +72,7 @@ public class ExwsStepTest {
 
         disk1 = new Disk(DISK_ID_ONE, "name one", pathToDisk1.getPath(), "jenkins-project/disk-one");
         disk2 = new Disk(DISK_ID_TWO, "name two", pathToDisk2.getPath(), "jenkins-project/disk-two");
-        DiskPool diskPool = new DiskPool(DISK_POOL_ID, "name", "desc", null, Arrays.asList(disk1, disk2));
+        DiskPool diskPool = new DiskPool(DISK_POOL_ID, "name", "desc", null, null, Arrays.asList(disk1, disk2));
         setUpDiskPools(j.jenkins, Collections.singletonList(diskPool));
 
         diskNode1 = new DiskNode(DISK_ID_ONE, pathToDisk1.getPath());

--- a/src/test/java/org/jenkinsci/plugins/ewm/steps/WorkspaceCleanupTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/steps/WorkspaceCleanupTest.java
@@ -58,7 +58,7 @@ public class WorkspaceCleanupTest {
         node2 = j.createSlave(Label.get("test"));
 
         Disk disk = new Disk(DISK_ID_ONE, null, "mount-from-master", PATH_ON_DISK);
-        DiskPool diskPool = new DiskPool(DISK_POOL_ID, null, null, null, Collections.singletonList(disk));
+        DiskPool diskPool = new DiskPool(DISK_POOL_ID, null, null, null, null, Collections.singletonList(disk));
         setUpDiskPools(j.jenkins, Collections.singletonList(diskPool));
     }
 


### PR DESCRIPTION
This is a PoC that fully integrates the [Job Restrictions plugin](https://github.com/jenkinsci/job-restrictions-plugin) for providing the Disk Pool Restriction mechanism.
It works very well, so maybe there is not need to provide an additional DiskPoolRestriction Extension Point? Somehow related to #25.

To be discussed.

**Later edit:**
Related to issue [[JENKINS-36962]](https://issues.jenkins-ci.org/browse/JENKINS-36962)

Summary of this pull request:
 - [X] Integrate the JobRestrictions plugin
 - [x] Write basic tests
 - [ ] Write basic documentation

CC @oleg-nenashev @martinda
