### PR TITLE
Info enhancement for the External Workspaces action

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateExecution.java
@@ -92,7 +92,12 @@ public class ExwsAllocateExecution extends AbstractSynchronousNonBlockingStepExe
                 }
             }
 
-            exws = new ExternalWorkspace(diskPoolId, diskId, pathOnDisk);
+            String masterMountPoint = disk.getMasterMountPoint();
+            if (masterMountPoint == null) {
+                String message = String.format("Mounting point from Master to the disk is not defined for Disk ID '%s'", diskId);
+                throw new AbortException(message);
+            }
+            exws = new ExternalWorkspace(diskPoolId, diskId, masterMountPoint, pathOnDisk);
         } else {
             // this is the downstream job
 

--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/model/ExternalWorkspace.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/model/ExternalWorkspace.java
@@ -16,12 +16,15 @@ public class ExternalWorkspace implements Serializable {
     private final String id;
     private final String diskPoolId;
     private final String diskId;
+    private final String masterMountPoint;
     private final String pathOnDisk;
 
-    public ExternalWorkspace(@Nonnull String diskPoolId, @Nonnull String diskId, @Nonnull String pathOnDisk) {
+    public ExternalWorkspace(@Nonnull String diskPoolId, @Nonnull String diskId,
+                             @Nonnull String masterMountPoint, @Nonnull String pathOnDisk) {
         this.id = UUID.randomUUID().toString();
         this.diskPoolId = diskPoolId;
         this.diskId = diskId;
+        this.masterMountPoint = masterMountPoint;
         this.pathOnDisk = pathOnDisk;
     }
 
@@ -38,6 +41,11 @@ public class ExternalWorkspace implements Serializable {
     @Nonnull
     public String getDiskId() {
         return diskId;
+    }
+
+    @Nonnull
+    public String getMasterMountPoint() {
+        return masterMountPoint;
     }
 
     @Nonnull

--- a/src/main/resources/org/jenkinsci/plugins/ewm/actions/ExwsAllocateActionImpl/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ewm/actions/ExwsAllocateActionImpl/index.jelly
@@ -6,16 +6,21 @@
             <j:forEach var="exws" items="${it.allocatedWorkspaces}">
                 <h2>${%Allocated External Workspace}</h2>
                 <p>
-                    ${%Disk Pool ID:}
+                    ${%Disk Pool ID}:
                     <j:out value="${exws.diskPoolId}"/>
                 </p>
                 <p>
-                    ${%Disk ID:}
+                    ${%Disk ID}:
                     <j:out value="${exws.diskId}"/>
                 </p>
                 <p>
-                    ${%Complete Path on Disk:}
+                    ${%Workspace path on} <j:out value="${exws.diskId}"/>:
                     <j:out value="${exws.pathOnDisk}"/>
+                </p>
+                <p>
+                    ${%Complete workspace path on} <j:out value="${exws.diskId}"/>
+                    (${%from Jenkins master}):
+                    <j:out value="${exws.masterMountPoint + '/' + exws.pathOnDisk}"/>
                 </p>
             </j:forEach>
             <j:if test="${it.allocatedWorkspaces.size() > 1}">

--- a/src/main/resources/org/jenkinsci/plugins/ewm/actions/ExwsAllocateActionImpl/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ewm/actions/ExwsAllocateActionImpl/index.jelly
@@ -6,21 +6,17 @@
             <j:forEach var="exws" items="${it.allocatedWorkspaces}">
                 <h2>${%Allocated External Workspace}</h2>
                 <p>
-                    ${%Disk Pool ID}:
-                    <j:out value="${exws.diskPoolId}"/>
+                    ${%Disk Pool ID}: ${exws.diskPoolId}
                 </p>
                 <p>
-                    ${%Disk ID}:
-                    <j:out value="${exws.diskId}"/>
+                    ${%Disk ID}: ${exws.diskId}
                 </p>
                 <p>
-                    ${%Workspace path on} <j:out value="${exws.diskId}"/>:
-                    <j:out value="${exws.pathOnDisk}"/>
+                    ${%Workspace path on} ${exws.diskId}: ${exws.pathOnDisk}
                 </p>
                 <p>
-                    ${%Complete workspace path on} <j:out value="${exws.diskId}"/>
-                    (${%from Jenkins master}):
-                    <j:out value="${exws.masterMountPoint + '/' + exws.pathOnDisk}"/>
+                    ${%Complete workspace path on} ${exws.diskId}
+                    (${%from Jenkins master}): ${exws.masterMountPoint + '/' + exws.pathOnDisk}
                 </p>
             </j:forEach>
             <j:if test="${it.allocatedWorkspaces.size() > 1}">


### PR DESCRIPTION
Summary of this pull request:
- [X] Enhance the info on the `External Workspaces` action

I have added mounting point from Jenkins Master to Disk

Before
<img width="682" alt="screen shot 2016-08-11 at 9 55 50 pm" src="https://cloud.githubusercontent.com/assets/5720977/17624261/941df84c-60ac-11e6-87e8-169e12b628b5.png">

After
<img width="1036" alt="screen shot 2016-08-11 at 10 22 42 pm" src="https://cloud.githubusercontent.com/assets/5720977/17624278/9d138066-60ac-11e6-9f24-bd6341ecbfcd.png">

CC @oleg-nenashev @martinda