### PR TITLE
Refactor test dependencies to include minimum workflow-cps 2.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,8 +88,26 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-aggregator</artifactId>
-            <version>2.2</version>
+            <artifactId>workflow-job</artifactId>
+            <version>2.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>2.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <version>2.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-basic-steps</artifactId>
+            <version>2.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.9</version>
+        <version>2.13</version>
     </parent>
 
     <artifactId>external-workspace-manager</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -122,5 +122,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>pl.pragmatists</groupId>
+            <artifactId>JUnitParams</artifactId>
+            <version>1.0.5</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/test/java/org/jenkinsci/plugins/ewm/steps/DiskAllocationStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/steps/DiskAllocationStrategyTest.java
@@ -1,6 +1,8 @@
 package org.jenkinsci.plugins.ewm.steps;
 
 import hudson.model.Result;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.jenkinsci.plugins.ewm.TestUtil;
 import org.jenkinsci.plugins.ewm.definitions.Disk;
 import org.jenkinsci.plugins.ewm.definitions.DiskPool;
@@ -11,6 +13,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 
@@ -21,6 +24,7 @@ import static java.lang.String.format;
  *
  * @author Alexandru Somai
  */
+@RunWith(JUnitParamsRunner.class)
 public class DiskAllocationStrategyTest {
 
     @ClassRule
@@ -35,14 +39,16 @@ public class DiskAllocationStrategyTest {
     }
 
     @Test
-    public void useAllocationStrategyInPipeline() throws Exception {
+    @Parameters({"fastestWriteSpeed()",
+                 "[$class: 'FastestWriteSpeedStrategy']"})
+    public void useAllocationStrategyInPipeline(String strategy) throws Exception {
         Disk disk1 = TestUtil.createDisk(new UserProvidedDiskInfo(0, 1));
         Disk disk2 = TestUtil.createDisk(new UserProvidedDiskInfo(0, 3));
         DiskPool diskPool = TestUtil.createDiskPool(disk1, disk2);
         TestUtil.setUpDiskPools(j.jenkins, diskPool);
 
         WorkflowRun run = TestUtil.createWorkflowJobAndRun(j.jenkins, format("" +
-                "exwsAllocate diskPoolId: '%s', strategy: fastestWriteSpeed()", diskPool.getDiskPoolId()));
+                "exwsAllocate diskPoolId: '%s', strategy: %s", diskPool.getDiskPoolId(), strategy));
 
         j.assertBuildStatusSuccess(run);
         j.assertLogContains(format("Using Disk allocation strategy: '%s'", new FastestWriteSpeedStrategy().getDescriptor().getDisplayName()), run);
@@ -50,7 +56,9 @@ public class DiskAllocationStrategyTest {
     }
 
     @Test
-    public void diskHasNotEnoughUsableSpace() throws Exception {
+    @Parameters({"fastestWriteSpeed(estimatedWorkspaceSize: 300)",
+                 "[$class: 'FastestWriteSpeedStrategy'\\, estimatedWorkspaceSize: 300]"})
+    public void diskHasNotEnoughUsableSpace(String strategy) throws Exception {
         // The Disk mounting point parameter isn't an actual mount.
         // Therefore, the disk's usable space will be 0, and the job will fail as expected
         Disk disk = new Disk("disk", null, "not-an-actual-mounting-point", null, null);
@@ -59,9 +67,8 @@ public class DiskAllocationStrategyTest {
         long estimatedWorkspaceSize = 300;
 
         WorkflowRun run = TestUtil.createWorkflowJobAndRun(j.jenkins, format("" +
-                        "exwsAllocate diskPoolId: '%s', " +
-                        " strategy: fastestWriteSpeed(estimatedWorkspaceSize: %s)",
-                diskPool.getDiskPoolId(), estimatedWorkspaceSize));
+                "exwsAllocate diskPoolId: '%s', " +
+                " strategy: %s", diskPool.getDiskPoolId(), strategy));
 
         j.assertBuildStatus(Result.FAILURE, run);
         j.assertLogContains(format("Using Disk allocation strategy: '%s'", new FastestWriteSpeedStrategy().getDescriptor().getDisplayName()), run);

--- a/src/test/java/org/jenkinsci/plugins/ewm/steps/DiskAllocationStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/steps/DiskAllocationStrategyTest.java
@@ -42,7 +42,7 @@ public class DiskAllocationStrategyTest {
         TestUtil.setUpDiskPools(j.jenkins, diskPool);
 
         WorkflowRun run = TestUtil.createWorkflowJobAndRun(j.jenkins, format("" +
-                "exwsAllocate diskPoolId: '%s', strategy: [$class: 'FastestWriteSpeedStrategy']", diskPool.getDiskPoolId()));
+                "exwsAllocate diskPoolId: '%s', strategy: fastestWriteSpeed()", diskPool.getDiskPoolId()));
 
         j.assertBuildStatusSuccess(run);
         j.assertLogContains(format("Using Disk allocation strategy: '%s'", new FastestWriteSpeedStrategy().getDescriptor().getDisplayName()), run);
@@ -60,7 +60,7 @@ public class DiskAllocationStrategyTest {
 
         WorkflowRun run = TestUtil.createWorkflowJobAndRun(j.jenkins, format("" +
                         "exwsAllocate diskPoolId: '%s', " +
-                        " strategy: [$class: 'FastestWriteSpeedStrategy', estimatedWorkspaceSize: %s]",
+                        " strategy: fastestWriteSpeed(estimatedWorkspaceSize: %s)",
                 diskPool.getDiskPoolId(), estimatedWorkspaceSize));
 
         j.assertBuildStatus(Result.FAILURE, run);


### PR DESCRIPTION
I have refactored the test dependencies.

I needed minimum `workflow-cps` version 2.10 to be able to test `@Symbol` for disk allocation strategies. 
`workflow-aggregator` was not working very well with `workflow-cps` 2.10, so I have removed it, and added the needed dependencies separately.

CC @oleg-nenashev @martinda