### PR TITLE
Specify maximum memory allocation pool for JVM

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 /* Only keep the 10 most recent builds */
 properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', numToKeepStr: '10']]])
 
-node ('kelp') {
+node {
   stage 'Checkout'
   checkout scm
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,8 @@
     <properties>
         <jenkins.version>1.642.3</jenkins.version>
         <java.level>7</java.level>
+
+        <argLine>-Xmx1024m</argLine>
     </properties>
 
     <name>External Workspace Manager Plugin</name>


### PR DESCRIPTION
Related to issue [[INFRA-899]](https://issues.jenkins-ci.org/browse/INFRA-899)

I had issues when my build was running on `celery` agent from [ci.jenkins.io](https://ci.jenkins.io/).
After some investigations, I've reached to the conclusion that I should set an `-Xmx` value to force the build to allocate enough memory on that agent.

I don't know if this is the best approach, but at least it's working.

CC @oleg-nenashev @martinda