### PR TITLE
Estimated workspace size conversion fix

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ewm/DiskAllocationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/DiskAllocationStrategy.java
@@ -21,6 +21,9 @@ import java.util.List;
  */
 public abstract class DiskAllocationStrategy extends AbstractDescribableImpl<DiskAllocationStrategy> implements ExtensionPoint {
 
+    private static final long MEGABYTE = 1024L * 1024L;
+
+    // estimated workspace size has to be in MB
     private long estimatedWorkspaceSize;
 
     /**
@@ -55,13 +58,13 @@ public abstract class DiskAllocationStrategy extends AbstractDescribableImpl<Dis
      * It uses the mounting point property that is defined in the Jenkins global config for each Disk.
      *
      * @param disk the disk entry
-     * @return the usable space in bytes for the disk
+     * @return the disk's usable space in bytes
      * @throws IOException if mounting point from Jenkins master to Disk is {@code null}, or
      *                     if the usable space can't be retrieved for security reasons
      * @see File#getUsableSpace
      */
     @Restricted(NoExternalUse.class)
-    public long retrieveUsableSpace(Disk disk) throws IOException {
+    public long retrieveUsableSpaceInBytes(Disk disk) throws IOException {
         String masterMountPoint = disk.getMasterMountPoint();
         if (masterMountPoint == null) {
             String message = String.format("Mounting point from Master to the disk is not defined for Disk ID '%s'", disk.getDiskId());
@@ -75,21 +78,48 @@ public abstract class DiskAllocationStrategy extends AbstractDescribableImpl<Dis
         }
     }
 
+    /**
+     * Retrieves the usable space in MB for the given {@link Disk} entry.
+     * It converts the value returned by {@link #retrieveUsableSpaceInBytes(Disk)} to MB.
+     *
+     * @param disk the disk entry
+     * @return the disk's usable space in MB
+     * @throws IOException same as {@link #retrieveUsableSpaceInBytes(Disk)}
+     * @see #retrieveUsableSpaceInBytes(Disk)
+     * @see #bytesToMega(long)
+     */
+    @Restricted(NoExternalUse.class)
+    protected final long retrieveUsableSpaceInMegaBytes(Disk disk) throws IOException {
+        return bytesToMega(retrieveUsableSpaceInBytes(disk));
+    }
+
+    /**
+     * Converts the given bytes value to megabytes.
+     * The formula used is bytes / (1024 * 1024).
+     *
+     * @param bytes the given value in bytes
+     * @return the converted value to megabytes
+     */
+    private static long bytesToMega(long bytes) {
+        return bytes / MEGABYTE;
+    }
+
+    /**
+     * Returns the estimated workspace size in MB.
+     *
+     * @return the estimated workspace size in MB
+     */
     public long getEstimatedWorkspaceSize() {
         return estimatedWorkspaceSize;
     }
 
+    /**
+     * Sets the estimated workspace size.
+     * It must be set in MB.
+     *
+     * @param estimatedWorkspaceSize the estimated workspace size in MB
+     */
     public void setEstimatedWorkspaceSize(long estimatedWorkspaceSize) {
         this.estimatedWorkspaceSize = estimatedWorkspaceSize;
-    }
-
-    /**
-     * Assuming that the {@link #estimatedWorkspaceSize} is provided by the user in MB,
-     * this method returns the size in bytes (multiplied by 1024 * 1024).
-     *
-     * @return the estimated workspace size in bytes (multiplied by 1024 * 1024)
-     */
-    public long getEstimatedWorkspaceSizeInBytes() {
-        return estimatedWorkspaceSize * 1024 * 1024;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ewm/DiskAllocationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/DiskAllocationStrategy.java
@@ -51,11 +51,11 @@ public abstract class DiskAllocationStrategy extends AbstractDescribableImpl<Dis
     public abstract Disk allocateDisk(@Nonnull List<Disk> disks) throws IOException;
 
     /**
-     * Calculates the usable space for the given {@link Disk} entry.
+     * Retrieves the usable space in bytes for the given {@link Disk} entry.
      * It uses the mounting point property that is defined in the Jenkins global config for each Disk.
      *
      * @param disk the disk entry
-     * @return the usable space for the disk
+     * @return the usable space in bytes for the disk
      * @throws IOException if mounting point from Jenkins master to Disk is {@code null}, or
      *                     if the usable space can't be retrieved for security reasons
      * @see File#getUsableSpace
@@ -85,11 +85,11 @@ public abstract class DiskAllocationStrategy extends AbstractDescribableImpl<Dis
 
     /**
      * Assuming that the {@link #estimatedWorkspaceSize} is provided by the user in MB,
-     * this method returns the size in KB (multiplied by 1024).
+     * this method returns the size in bytes (multiplied by 1024 * 1024).
      *
-     * @return the estimated workspace size in KB (multiplied by 1024)
+     * @return the estimated workspace size in bytes (multiplied by 1024 * 1024)
      */
-    public long getEstimatedWorkspaceSizeInKilobytes() {
-        return estimatedWorkspaceSize * 1024;
+    public long getEstimatedWorkspaceSizeInBytes() {
+        return estimatedWorkspaceSize * 1024 * 1024;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ewm/strategies/AbstractDiskSpeedStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/strategies/AbstractDiskSpeedStrategy.java
@@ -20,13 +20,13 @@ public abstract class AbstractDiskSpeedStrategy extends DiskAllocationStrategy {
     @Nonnull
     @Override
     public Disk allocateDisk(@Nonnull List<Disk> disks) throws IOException {
-        long estimatedWorkspaceSizeInKilobytes = getEstimatedWorkspaceSizeInKilobytes();
+        long estimatedWorkspaceSizeInBytes = getEstimatedWorkspaceSizeInBytes();
         Disk candidate = null;
 
         for (Disk disk : disks) {
             long usableSpace = retrieveUsableSpace(disk);
 
-            if (candidate == null && usableSpace >= estimatedWorkspaceSizeInKilobytes) {
+            if (candidate == null && usableSpace >= estimatedWorkspaceSizeInBytes) {
                 // found a possible candidate that has the usable space >= estimated workspace size
                 candidate = disk;
             }
@@ -36,7 +36,7 @@ public abstract class AbstractDiskSpeedStrategy extends DiskAllocationStrategy {
                 int candidateSpeed = getDiskSpeed(candidate.getDiskInfo());
                 int diskSpeed = getDiskSpeed(disk.getDiskInfo());
 
-                if (diskSpeed > candidateSpeed && usableSpace >= estimatedWorkspaceSizeInKilobytes) {
+                if (diskSpeed > candidateSpeed && usableSpace >= estimatedWorkspaceSizeInBytes) {
                     // found another disk that has higher speed than the candidate's speed and the usable space >= estimated workspace size
                     candidate = disk;
                 }

--- a/src/main/java/org/jenkinsci/plugins/ewm/strategies/AbstractDiskSpeedStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/strategies/AbstractDiskSpeedStrategy.java
@@ -20,13 +20,13 @@ public abstract class AbstractDiskSpeedStrategy extends DiskAllocationStrategy {
     @Nonnull
     @Override
     public Disk allocateDisk(@Nonnull List<Disk> disks) throws IOException {
-        long estimatedWorkspaceSizeInBytes = getEstimatedWorkspaceSizeInBytes();
+        long estimatedWorkspaceSize = getEstimatedWorkspaceSize();
         Disk candidate = null;
 
         for (Disk disk : disks) {
-            long usableSpace = retrieveUsableSpace(disk);
+            long usableSpaceMegaBytes = retrieveUsableSpaceInMegaBytes(disk);
 
-            if (candidate == null && usableSpace >= estimatedWorkspaceSizeInBytes) {
+            if (candidate == null && usableSpaceMegaBytes >= estimatedWorkspaceSize) {
                 // found a possible candidate that has the usable space >= estimated workspace size
                 candidate = disk;
             }
@@ -36,7 +36,7 @@ public abstract class AbstractDiskSpeedStrategy extends DiskAllocationStrategy {
                 int candidateSpeed = getDiskSpeed(candidate.getDiskInfo());
                 int diskSpeed = getDiskSpeed(disk.getDiskInfo());
 
-                if (diskSpeed > candidateSpeed && usableSpace >= estimatedWorkspaceSizeInBytes) {
+                if (diskSpeed > candidateSpeed && usableSpaceMegaBytes >= estimatedWorkspaceSize) {
                     // found another disk that has higher speed than the candidate's speed and the usable space >= estimated workspace size
                     candidate = disk;
                 }

--- a/src/main/java/org/jenkinsci/plugins/ewm/strategies/MostUsableSpaceStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/strategies/MostUsableSpaceStrategy.java
@@ -49,7 +49,7 @@ public class MostUsableSpaceStrategy extends DiskAllocationStrategy {
             }
         }
 
-        if (selectedDiskUsableSpace < getEstimatedWorkspaceSizeInKilobytes()) {
+        if (selectedDiskUsableSpace < getEstimatedWorkspaceSizeInBytes()) {
             String message = String.format("The selected Disk with the most usable space doesn't have at least %s MB space", getEstimatedWorkspaceSize());
             throw new AbortException(message);
         }

--- a/src/main/java/org/jenkinsci/plugins/ewm/strategies/MostUsableSpaceStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/strategies/MostUsableSpaceStrategy.java
@@ -37,19 +37,19 @@ public class MostUsableSpaceStrategy extends DiskAllocationStrategy {
     public Disk allocateDisk(@Nonnull List<Disk> disks) throws IOException {
         Iterator<Disk> iterator = disks.iterator();
         Disk selectedDisk = iterator.next();
-        long selectedDiskUsableSpace = retrieveUsableSpace(selectedDisk);
+        long selectedDiskUsableSpaceBytes = retrieveUsableSpaceInBytes(selectedDisk);
 
         while (iterator.hasNext()) {
             Disk disk = iterator.next();
-            long diskUsableSpace = retrieveUsableSpace(disk);
+            long diskUsableSpaceBytes = retrieveUsableSpaceInBytes(disk);
 
-            if (diskUsableSpace > selectedDiskUsableSpace) {
+            if (diskUsableSpaceBytes > selectedDiskUsableSpaceBytes) {
                 selectedDisk = disk;
-                selectedDiskUsableSpace = diskUsableSpace;
+                selectedDiskUsableSpaceBytes = diskUsableSpaceBytes;
             }
         }
 
-        if (selectedDiskUsableSpace < getEstimatedWorkspaceSizeInBytes()) {
+        if (retrieveUsableSpaceInMegaBytes(selectedDisk) < getEstimatedWorkspaceSize()) {
             String message = String.format("The selected Disk with the most usable space doesn't have at least %s MB space", getEstimatedWorkspaceSize());
             throw new AbortException(message);
         }

--- a/src/test/java/org/jenkinsci/plugins/ewm/strategies/AbstractDiskSpeedStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/strategies/AbstractDiskSpeedStrategyTest.java
@@ -45,8 +45,8 @@ public abstract class AbstractDiskSpeedStrategyTest<T extends AbstractDiskSpeedS
         strategy.setEstimatedWorkspaceSize(estimatedWorkspaceSize);
         Disk disk = TestUtil.createDisk();
 
-        // simulate 100 MB available space
-        when(strategy.retrieveUsableSpace(disk)).thenReturn(100000000L);
+        // simulate ~100 MB available space
+        when(strategy.retrieveUsableSpaceInBytes(disk)).thenReturn(100000000L);
 
         thrown.expect(AbortException.class);
         thrown.expectMessage(format("Couldn't find any Disk with at least %s MB usable space", estimatedWorkspaceSize));

--- a/src/test/java/org/jenkinsci/plugins/ewm/strategies/AbstractDiskSpeedStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/strategies/AbstractDiskSpeedStrategyTest.java
@@ -40,11 +40,13 @@ public abstract class AbstractDiskSpeedStrategyTest<T extends AbstractDiskSpeedS
 
     @Test
     public void estimatedWorkspaceSizeGreaterThanUsableSpace() throws Exception {
+        // estimated workspace size of 200 MB
         long estimatedWorkspaceSize = 200L;
         strategy.setEstimatedWorkspaceSize(estimatedWorkspaceSize);
         Disk disk = TestUtil.createDisk();
 
-        when(strategy.retrieveUsableSpace(disk)).thenReturn(100000L);
+        // simulate 100 MB available space
+        when(strategy.retrieveUsableSpace(disk)).thenReturn(100000000L);
 
         thrown.expect(AbortException.class);
         thrown.expectMessage(format("Couldn't find any Disk with at least %s MB usable space", estimatedWorkspaceSize));

--- a/src/test/java/org/jenkinsci/plugins/ewm/strategies/MostUsableSpaceStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/strategies/MostUsableSpaceStrategyTest.java
@@ -40,9 +40,9 @@ public class MostUsableSpaceStrategyTest {
         Disk disk2 = TestUtil.createDisk();
         Disk disk3 = TestUtil.createDisk();
 
-        when(strategy.retrieveUsableSpace(disk1)).thenReturn(1L);
-        when(strategy.retrieveUsableSpace(disk2)).thenReturn(200L);
-        when(strategy.retrieveUsableSpace(disk3)).thenReturn(3L);
+        when(strategy.retrieveUsableSpaceInBytes(disk1)).thenReturn(1L);
+        when(strategy.retrieveUsableSpaceInBytes(disk2)).thenReturn(200L);
+        when(strategy.retrieveUsableSpaceInBytes(disk3)).thenReturn(3L);
 
         Disk allocatedDisk = strategy.allocateDisk(Arrays.asList(disk1, disk2));
         assertThat(allocatedDisk, is(disk2));
@@ -64,8 +64,8 @@ public class MostUsableSpaceStrategyTest {
         strategy.setEstimatedWorkspaceSize(estimatedWorkspaceSize);
         Disk disk = TestUtil.createDisk();
 
-        // simulate 100 MB available space
-        when(strategy.retrieveUsableSpace(disk)).thenReturn(100000000L);
+        // simulate ~100 MB available space
+        when(strategy.retrieveUsableSpaceInBytes(disk)).thenReturn(100000000L);
 
         thrown.expect(AbortException.class);
         thrown.expectMessage(format("The selected Disk with the most usable space doesn't have at least %s MB space", estimatedWorkspaceSize));

--- a/src/test/java/org/jenkinsci/plugins/ewm/strategies/MostUsableSpaceStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/strategies/MostUsableSpaceStrategyTest.java
@@ -59,11 +59,13 @@ public class MostUsableSpaceStrategyTest {
 
     @Test
     public void estimatedWorkspaceSizeGreaterThanUsableSpace() throws Exception {
+        // estimated workspace size of 200 MB
         long estimatedWorkspaceSize = 200L;
         strategy.setEstimatedWorkspaceSize(estimatedWorkspaceSize);
         Disk disk = TestUtil.createDisk();
 
-        when(strategy.retrieveUsableSpace(disk)).thenReturn(100000L);
+        // simulate 100 MB available space
+        when(strategy.retrieveUsableSpace(disk)).thenReturn(100000000L);
 
         thrown.expect(AbortException.class);
         thrown.expectMessage(format("The selected Disk with the most usable space doesn't have at least %s MB space", estimatedWorkspaceSize));


### PR DESCRIPTION
A minor conversion bug that I've found.

I didn't read very well the documentation, the method `File#getUsableSpace` returns the usable space in bytes, not in kilobytes as I thought.
Therefore, I was comparing bytes with kilobytes when the `estimatedWorkspaceSize` parameter was provided.

This is difficult to cover with automated tests, because I am not using real mounting points, to get real values. I am using only mocks.

CC @oleg-nenashev @martinda

