### PR TITLE
[JENKINS-39198] Fix workspace allocation in parallel test execution

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsExecution.java
@@ -90,17 +90,14 @@ public class ExwsExecution extends AbstractStepExecutionImpl {
         NodeDisk nodeDisk = findNodeDisk(exws.getDiskId(), nodeDiskPool.getNodeDisks(), node.getDisplayName());
 
         FilePath diskFilePath = new FilePath(node.getChannel(), nodeDisk.getNodeMountPoint());
-        FilePath baseWorkspace = diskFilePath.child(exws.getPathOnDisk());
-
-        WorkspaceList.Lease lease = computer.getWorkspaceList().allocate(baseWorkspace);
-        FilePath workspace = lease.path;
+        FilePath workspace = diskFilePath.child(exws.getPathOnDisk());
 
         updateFingerprint(exws.getId());
 
         listener.getLogger().println("Running in " + workspace);
         body = getContext().newBodyInvoker()
                 .withContext(workspace)
-                .withCallback(new Callback(getContext(), lease))
+                .withCallback(BodyExecutionCallback.wrap(getContext()))
                 .start();
         return false;
     }
@@ -233,6 +230,7 @@ public class ExwsExecution extends AbstractStepExecutionImpl {
         return selected;
     }
 
+    @Deprecated
     private static final class Callback extends BodyExecutionCallback {
 
         private final StepContext context;


### PR DESCRIPTION
Related to issue [[JENKINS-39198]](https://issues.jenkins-ci.org/browse/JENKINS-39198)

The plugin has some problems when trying to run parallel tests using the same workspace, especially when running on the same node. This is because when the workspace directory is created, the method used for workspace allocation is `WorkspaceList#allocate(FilePath)`. This ads a variation to the workspace if it's in use, to make it unique, e.g. _workspace@2_, _workspace@3_, etc.
IMO we don't need this unique workspace allocation, and the workspace should be created/used without this.

Here are the Pipeline's I've used for testing this:
- Upstream job, named _test-parallel_:
  https://gist.github.com/alexsomai/654beb50aa9037a85c82500207b9837d
- Downstream job, named _run-test-suite_:
  https://gist.github.com/alexsomai/81c4ba27a828eb2e5ed73b0dd1805883

CC @oleg-nenashev @martinda 
