### PR TITLE
Add delete disk pool button to templates and nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ work
 
 # IntelliJ
 .idea
+
+# Vim
+*.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+- Add delete disk pool button to template and nodes
+[#49](https://github.com/jenkinsci/external-workspace-manager-plugin/pull/49)
+
 ## 1.1.1 - 2016-11-08
 ### Fixed
 - [[JENKINS-39198]](https://issues.jenkins-ci.org/browse/JENKINS-39198) Fix workspace allocation in parallel test 

--- a/src/main/resources/org/jenkinsci/plugins/ewm/nodes/NodeDiskPool/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ewm/nodes/NodeDiskPool/config.jelly
@@ -6,4 +6,9 @@
     <f:entry>
         <f:repeatableProperty field="nodeDisks" add="${%Add Disk}" header="${%Disk}"/>
     </f:entry>
+    <f:entry>
+        <div align="right">
+            <f:repeatableDeleteButton value="${%Delete Disk Pool}"/>
+        </div>
+    </f:entry>
 </j:jelly>


### PR DESCRIPTION
Add button to delete disk pool in template and in node configurations

Summary of this pull request:
- Add .gitignore entry for vim
- Add delete disk pool button to template in global config, and to disk pool in node configuration

CC @alexsomai @oleg-nenashev 
