### PR TITLE
[DO NOT MERGE YET] A simplistic solution for configuration as code compliance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,5 +130,11 @@
             <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.jenkins</groupId>
+            <artifactId>configuration-as-code</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep.java
@@ -111,6 +111,11 @@ public final class ExwsAllocateStep extends AbstractStepImpl {
             return Collections.unmodifiableList(diskPools);
         }
 
+        public void setDiskPools(List<DiskPool> diskPools) {
+            this.diskPools.clear();
+            this.diskPools.addAll(diskPools);
+        }
+
         @Restricted(NoExternalUse.class)
         @SuppressWarnings("unused")
         public FormValidation doCheckPath(@QueryParameter String value) {

--- a/src/test/java/org/jenkinsci/plugins/ewm/ConfigAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/ConfigAsCodeTest.java
@@ -1,0 +1,28 @@
+package org.jenkinsci.plugins.ewm;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.is;
+import org.jvnet.hudson.test.JenkinsRule;
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+
+/**
+ * Test for Configuration As Code Compatibility.
+ *
+ * @author Martin d'Anjou
+ */
+public class ConfigAsCodeTest {
+
+    @ClassRule public static JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void should_support_configuration_as_code() throws Exception {
+        String config = ConfigAsCodeTest.class.getResource("configuration-as-code.yaml").toString(); //configuration-as-code.yml").toString();
+        System.out.println("config: " + config);
+        ConfigurationAsCode.get().configure(config);
+        assertTrue(true); // check plugin has been configured as expected );
+    }
+
+}

--- a/src/test/resources/org/jenkinsci/plugins/ewm/configuration-as-code.yaml
+++ b/src/test/resources/org/jenkinsci/plugins/ewm/configuration-as-code.yaml
@@ -1,0 +1,9 @@
+unclassified:
+  exwsallocatestep:
+    diskPools:
+    - diskPoolId: "diskpool1"
+      disks:
+      - diskId: "disk1"
+        displayName: "disk one display name"
+        masterMountPoint: "/tmp"
+      displayName: "diskpool1 display name"

--- a/src/test/resources/org/jenkinsci/plugins/ewm/configuration-as-code.yaml
+++ b/src/test/resources/org/jenkinsci/plugins/ewm/configuration-as-code.yaml
@@ -1,9 +1,9 @@
 unclassified:
-  exwsallocatestep:
-    diskPools:
-    - diskPoolId: "diskpool1"
-      disks:
-      - diskId: "disk1"
-        displayName: "disk one display name"
-        masterMountPoint: "/tmp"
-      displayName: "diskpool1 display name"
+    exwsallocatestep:
+      diskPools:
+          - diskPoolId: "diskpool1"
+            disks:
+                - diskId: "disk1"
+                  displayName: "disk one display name"
+                  masterMountPoint: "/tmp"
+            displayName: "diskpool1 display name"

--- a/src/test/resources/org/jenkinsci/plugins/ewm/configuration-as-code.yaml
+++ b/src/test/resources/org/jenkinsci/plugins/ewm/configuration-as-code.yaml
@@ -1,9 +1,9 @@
 unclassified:
     exwsallocatestep:
-      diskPools:
-          - diskPoolId: "diskpool1"
-            disks:
-                - diskId: "disk1"
-                  displayName: "disk one display name"
-                  masterMountPoint: "/tmp"
-            displayName: "diskpool1 display name"
+        diskPools:
+            - diskPoolId: "diskpool1"
+              disks:
+                  - diskId: "disk1"
+                    displayName: "disk one display name"
+                    masterMountPoint: "/tmp"
+              displayName: "diskpool1 display name"


### PR DESCRIPTION
This is a simplistic attempt at making this plugin compliant with [Configuration as Code](https://github.com/jenkinsci/configuration-as-code-plugin)

Summary of this pull request:
- Add a setter to the list of diskPools

Next: it would be a better idea to use the [PersistedList](https://javadoc.jenkins.io/hudson/util/PersistedList.html) class, I will try to provide that too.

CC @oleg-nenashev @alexso