### PR TITLE
Casc compatibility using PersistedList

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,5 +130,11 @@
             <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.jenkins</groupId>
+            <artifactId>configuration-as-code</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.synopsys.arc.jenkinsci.plugins</groupId>
             <artifactId>job-restrictions</artifactId>
-            <version>0.5</version>
+            <version>0.8</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep.java
@@ -93,7 +93,7 @@ public final class ExwsAllocateStep extends AbstractStepImpl {
     @Extension
     public static class DescriptorImpl extends AbstractStepDescriptorImpl {
 
-        public PersistedList<DiskPool> diskPools = new PersistedList<>(this);
+        public final PersistedList<DiskPool> diskPools = new PersistedList<>(this);
 
         public DescriptorImpl() {
             super(ExwsAllocateExecution.class);

--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.ewm.steps;
 
 import hudson.Extension;
 import hudson.util.FormValidation;
+import hudson.util.PersistedList;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.ewm.DiskAllocationStrategy;
 import org.jenkinsci.plugins.ewm.Messages;
@@ -92,7 +93,7 @@ public final class ExwsAllocateStep extends AbstractStepImpl {
     @Extension
     public static class DescriptorImpl extends AbstractStepDescriptorImpl {
 
-        private List<DiskPool> diskPools = Collections.emptyList();
+        public final PersistedList<DiskPool> diskPools = new PersistedList<>(this);
 
         public DescriptorImpl() {
             super(ExwsAllocateExecution.class);
@@ -101,14 +102,9 @@ public final class ExwsAllocateStep extends AbstractStepImpl {
 
         @Override
         public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
-            diskPools = req.bindJSONToList(DiskPool.class, formData.get("diskPools"));
+            req.bindJSON(this, formData);
             save();
-            return super.configure(req, formData);
-        }
-
-        @Nonnull
-        public List<DiskPool> getDiskPools() {
-            return Collections.unmodifiableList(diskPools);
+            return true;
         }
 
         @Restricted(NoExternalUse.class)

--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep.java
@@ -93,7 +93,7 @@ public final class ExwsAllocateStep extends AbstractStepImpl {
     @Extension
     public static class DescriptorImpl extends AbstractStepDescriptorImpl {
 
-        public final PersistedList<DiskPool> diskPools = new PersistedList<>(this);
+        public PersistedList<DiskPool> diskPools = new PersistedList<>(this);
 
         public DescriptorImpl() {
             super(ExwsAllocateExecution.class);

--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStep.java
@@ -107,6 +107,11 @@ public final class ExwsAllocateStep extends AbstractStepImpl {
             return true;
         }
 
+        @Nonnull
+        public List<DiskPool> getDiskPools() {
+            return Collections.unmodifiableList(diskPools);
+        }
+
         @Restricted(NoExternalUse.class)
         @SuppressWarnings("unused")
         public FormValidation doCheckPath(@QueryParameter String value) {

--- a/src/test/java/org/jenkinsci/plugins/ewm/ConfigAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/ConfigAsCodeTest.java
@@ -1,0 +1,28 @@
+package org.jenkinsci.plugins.ewm;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.is;
+import org.jvnet.hudson.test.JenkinsRule;
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+
+/**
+ * Test for Configuration As Code Compatibility.
+ *
+ * @author Martin d'Anjou
+ */
+public class ConfigAsCodeTest {
+
+    @ClassRule public static JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void should_support_configuration_as_code() throws Exception {
+        String config = ConfigAsCodeTest.class.getResource("configuration-as-code.yaml").toString(); //configuration-as-code.yml").toString();
+        System.out.println("config: " + config);
+        ConfigurationAsCode.get().configure(config);
+        assertTrue(true); // check plugin has been configured as expected );
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/ewm/ConfigAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/ConfigAsCodeTest.java
@@ -1,12 +1,21 @@
 package org.jenkinsci.plugins.ewm;
 
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+
+import org.jenkinsci.plugins.ewm.steps.ExwsAllocateStep;
 import org.junit.ClassRule;
 import org.junit.Test;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertThat;
-import static org.hamcrest.Matchers.is;
 import org.jvnet.hudson.test.JenkinsRule;
-import io.jenkins.plugins.casc.ConfigurationAsCode;
+
+// TODO: the following should not be necessary since they should be tested in the job-restriction plugin in the end
+import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.restrictions.job.RegexNameRestriction;
+import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.restrictions.job.StartedByUserRestriction;
+import com.synopsys.arc.jenkinsci.plugins.jobrestrictions.restrictions.logic.AndJobRestriction;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Test for Configuration As Code Compatibility.
@@ -15,14 +24,36 @@ import io.jenkins.plugins.casc.ConfigurationAsCode;
  */
 public class ConfigAsCodeTest {
 
-    @ClassRule public static JenkinsRule r = new JenkinsRule();
+    @ClassRule public static JenkinsRule j = new JenkinsRule();
 
     @Test
     public void should_support_configuration_as_code() throws Exception {
         String config = ConfigAsCodeTest.class.getResource("configuration-as-code.yaml").toString(); //configuration-as-code.yml").toString();
         System.out.println("config: " + config);
         ConfigurationAsCode.get().configure(config);
-        assertTrue(true); // check plugin has been configured as expected );
+        ExwsAllocateStep.DescriptorImpl descriptor = (ExwsAllocateStep.DescriptorImpl) j.jenkins.getDescriptor(ExwsAllocateStep.class);
+        assertThat(descriptor.diskPools.size(), is(1));
+        assertThat(descriptor.diskPools.get(0).getDiskPoolId(), is("diskpool1"));
+        assertThat(descriptor.diskPools.get(0).getDisplayName(), is("diskpool1 display name"));
+        assertThat(descriptor.diskPools.get(0).getDescription(), is("diskpool1 description"));
+        // TODO: find out why this next one does not work
+        // assertThat(descriptor.diskPools.get(0).getWorkspaceTemplate(), is("${JOB_NAME}/${CUSTOM_BUILD_PARAM}/${BUILD_NUMBER}"));
+        assertThat(descriptor.diskPools.get(0).getDisks().size(), is(1));
+        assertThat(descriptor.diskPools.get(0).getDisks().get(0).getDiskId(), is("disk1"));
+        assertThat(descriptor.diskPools.get(0).getDisks().get(0).getDisplayName(), is("disk one display name"));
+        assertThat(descriptor.diskPools.get(0).getDisks().get(0).getMasterMountPoint(), is("/tmp"));
+        assertThat(descriptor.diskPools.get(0).getDisks().get(0).getPhysicalPathOnDisk(), is("some/path"));
+        assertNotNull(descriptor.diskPools.get(0).getDisks().get(0).getDiskInfo());
+        assertThat(descriptor.diskPools.get(0).getDisks().get(0).getDiskInfo().getReadSpeed(), is (10));
+        assertThat(descriptor.diskPools.get(0).getDisks().get(0).getDiskInfo().getWriteSpeed(), is (5));
+
+        // TODO: These should only check that the restriction exists, the restriction details should be tested in the job-restriction-plugin itself
+        assertNotNull(descriptor.diskPools.get(0).getRestriction());
+        assertThat(descriptor.diskPools.get(0).getRestriction().getDescriptor().getDisplayName(), is("And"));
+        assertTrue(descriptor.diskPools.get(0).getRestriction() instanceof AndJobRestriction);
+        AndJobRestriction ajr = (AndJobRestriction)descriptor.diskPools.get(0).getRestriction();
+        assertTrue(ajr.getFirst() instanceof RegexNameRestriction);
+        assertTrue(ajr.getSecond() instanceof StartedByUserRestriction);
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/ewm/TestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/TestUtil.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.ewm;
 
 import hudson.model.Node;
 import hudson.model.queue.QueueTaskFuture;
+import hudson.util.PersistedList;
 import hudson.util.ReflectionUtils;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.RandomStringUtils;
@@ -44,20 +45,17 @@ public final class TestUtil {
         // do not instantiate
     }
 
-    public static void setUpDiskPools(Jenkins jenkins, DiskPool... diskPools) {
+    public static void setUpDiskPools(Jenkins jenkins, DiskPool... diskPools) throws IOException {
         setUpDiskPools(jenkins, Arrays.asList(diskPools));
     }
 
-    public static void removeDiskPools(Jenkins jenkins) {
+    public static void removeDiskPools(Jenkins jenkins) throws IOException {
         setUpDiskPools(jenkins, Collections.<DiskPool>emptyList());
     }
 
-    private static void setUpDiskPools(Jenkins jenkins, List<DiskPool> diskPools) {
+    private static void setUpDiskPools(Jenkins jenkins, List<DiskPool> diskPools) throws IOException {
         ExwsAllocateStep.DescriptorImpl descriptor = (ExwsAllocateStep.DescriptorImpl) jenkins.getDescriptor(ExwsAllocateStep.class);
-
-        Field diskPoolsField = ReflectionUtils.findField(ExwsAllocateStep.DescriptorImpl.class, "diskPools");
-        diskPoolsField.setAccessible(true);
-        ReflectionUtils.setField(diskPoolsField, descriptor, diskPools);
+        descriptor.diskPools.replaceBy(diskPools);
     }
 
     public static Disk findAllocatedDisk(Disk... disks) {

--- a/src/test/java/org/jenkinsci/plugins/ewm/steps/CustomWorkspaceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/steps/CustomWorkspaceTest.java
@@ -190,7 +190,7 @@ public class CustomWorkspaceTest {
                 "The resulting path is: ${JOB_NAME_WITH_TYPO}" + File.separator + "1. Did you provide all the needed environment variables?", run);
     }
 
-    private static void setGlobalWorkspaceTemplate(String template) {
+    private static void setGlobalWorkspaceTemplate(String template) throws IOException {
         Disk disk = new Disk(DISK_ID_ONE, null, "mount", null, null);
         DiskPool diskPool = new DiskPool(DISK_POOL_ID, null, null, FilenameUtils.separatorsToSystem(template), null, null, Collections.singletonList(disk));
         setUpDiskPools(j.jenkins, diskPool);

--- a/src/test/java/org/jenkinsci/plugins/ewm/steps/DiskAllocationStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/steps/DiskAllocationStrategyTest.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.ewm.steps;
 
 import hudson.model.Result;
+import java.io.IOException;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.jenkinsci.plugins.ewm.TestUtil;
@@ -34,7 +35,7 @@ public class DiskAllocationStrategyTest {
     public static BuildWatcher watcher = new BuildWatcher();
 
     @After
-    public void tearDown() {
+    public void tearDown() throws IOException {
         TestUtil.removeDiskPools(j.jenkins);
     }
 

--- a/src/test/java/org/jenkinsci/plugins/ewm/steps/DiskPoolRestrictionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/steps/DiskPoolRestrictionTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.Future;
 
@@ -50,7 +51,7 @@ public class DiskPoolRestrictionTest {
     public static BuildWatcher watcher = new BuildWatcher();
 
     @After
-    public void tearDown() {
+    public void tearDown() throws IOException {
         SecurityContextHolder.getContext().setAuthentication(null);
         removeDiskPools(j.jenkins);
     }
@@ -180,7 +181,7 @@ public class DiskPoolRestrictionTest {
         j.assertLogContains(format("Disk Pool identified by '%s' is not accessible due to the applied Disk Pool restriction: Regular Expression (Job Name)", DISK_POOL_ID), run);
     }
 
-    private static void setUpDiskPoolRestriction(JobRestriction restriction) {
+    private static void setUpDiskPoolRestriction(JobRestriction restriction) throws IOException {
         Disk disk = new Disk(DISK_ID_ONE, null, "any", null, null);
         DiskPool diskPool = new DiskPool(DISK_POOL_ID, null, null, null, restriction, null, singletonList(disk));
         setUpDiskPools(j.jenkins, diskPool);

--- a/src/test/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateStepTest.java
@@ -51,7 +51,7 @@ public class ExwsAllocateStepTest {
     }
 
     @After
-    public void tearDown() {
+    public void tearDown() throws IOException {
         removeDiskPools(j.jenkins);
     }
 
@@ -201,7 +201,7 @@ public class ExwsAllocateStepTest {
         j.assertLogContains(format("The path on Disk is: %s", Paths.get(disk.getPhysicalPathOnDisk(), upstreamName, Integer.toString(upstreamRun.getNumber()))), downstreamRun);
     }
 
-    private void setUpDiskPool(Disk... disks) {
+    private void setUpDiskPool(Disk... disks) throws IOException {
         DiskPool diskPool = new DiskPool(DISK_POOL_ID, "name", "desc", null, null, null, Arrays.asList(disks));
         setUpDiskPools(j.jenkins, diskPool);
     }

--- a/src/test/resources/org/jenkinsci/plugins/ewm/configuration-as-code.yaml
+++ b/src/test/resources/org/jenkinsci/plugins/ewm/configuration-as-code.yaml
@@ -1,0 +1,9 @@
+unclassified:
+    exwsallocatestep:
+      diskPools:
+          - diskPoolId: "diskpool1"
+            disks:
+                - diskId: "disk1"
+                  displayName: "disk one display name"
+                  masterMountPoint: "/tmp"
+            displayName: "diskpool1 display name"

--- a/src/test/resources/org/jenkinsci/plugins/ewm/configuration-as-code.yaml
+++ b/src/test/resources/org/jenkinsci/plugins/ewm/configuration-as-code.yaml
@@ -2,8 +2,32 @@ unclassified:
     exwsallocatestep:
       diskPools:
           - diskPoolId: "diskpool1"
+            displayName: "diskpool1 display name"
+            description: "diskpool1 description"
+            workspaceTemplate: "${JOB_NAME}/${CUSTOM_BUILD_PARAM}/${BUILD_NUMBER}"
+
             disks:
                 - diskId: "disk1"
                   displayName: "disk one display name"
                   masterMountPoint: "/tmp"
-            displayName: "diskpool1 display name"
+                  physicalPathOnDisk: "some/path"
+                  diskInfo:
+                      userProvidedDiskInfo:
+                          readSpeed: 10
+                          writeSpeed: 5
+
+            restriction:
+                and:
+                    first:
+                        regexNameRestriction:
+                            checkShortName: false
+                            regexExpression: "jobName.*"
+                    second:
+                        startedByUserRestriction:
+                            acceptAnonymousUsers: true
+                            acceptAutomaticRuns: false
+                            checkUpstreamProjects: true
+                            usersList:
+                                - selectedUserId: "martin"
+                                - selectedUserId: "sally"
+


### PR DESCRIPTION
Adding Configuration as Code compatibility on top of an up to date pom, using the `PersistedList` approach used in PR #52 by @ndeloof 

Summary of this pull request:
- Use `PersistedList` data type
- Ensure getter remains in place

@ndeloof can you help please? This fails mvn test with the following in the stack trace:
```
[ERROR] fallbackToGlobalAllocationStrategy(org.jenkinsci.plugins.ewm.steps.DiskAllocationStrategyTest)  Time elapsed: 0 s  <<< ERROR!
java.lang.IllegalArgumentException: Can not set final hudson.util.PersistedList field org.jenkinsci.plugins.ewm.steps.ExwsAllocateStep$DescriptorImpl.diskPools to java.util.Collections$EmptyList
        at sun.reflect.UnsafeFieldAccessorImpl.throwSetIllegalArgumentException(UnsafeFieldAccessorImpl.java:167)
        at sun.reflect.UnsafeFieldAccessorImpl.throwSetIllegalArgumentException(UnsafeFieldAccessorImpl.java:171)
        at sun.reflect.UnsafeQualifiedObjectFieldAccessorImpl.set(UnsafeQualifiedObjectFieldAccessorImpl.java:83)
        at java.lang.reflect.Field.set(Field.java:764)
        at org.springframework.util.ReflectionUtils.setField(ReflectionUtils.java:96)
        at org.jenkinsci.plugins.ewm.TestUtil.setUpDiskPools(TestUtil.java:60)
        at org.jenkinsci.plugins.ewm.TestUtil.removeDiskPools(TestUtil.java:52)
        at org.jenkinsci.plugins.ewm.steps.DiskAllocationStrategyTest.tearDown(DiskAllocationStrategyTest.java:38)
        at sun.reflect.GeneratedMethodAccessor58.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
        at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:33)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
        at junitparams.JUnitParamsRunner.runChild(JUnitParamsRunner.java:421)
        at junitparams.JUnitParamsRunner.runChild(JUnitParamsRunner.java:386)
        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:548)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.lang.Thread.run(Thread.java:748)
```

CC @ewelinawilkosz @oleg-nenashev 
