### PR TITLE
Use FileDynamicPathContext for compatibility with Jenkins 2.150.x+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <packaging>hpi</packaging>
 
     <properties>
-        <jenkins.version>2.138.4</jenkins.version>
+        <jenkins.version>2.150.3</jenkins.version>
         <java.level>8</java.level>
         <argLine>-Xmx1024m</argLine>
     </properties>
@@ -61,7 +61,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.138.x</artifactId>
+                <artifactId>bom-2.150.x</artifactId>
                 <version>3</version>
                 <scope>import</scope>
                 <type>pom</type>
@@ -93,7 +93,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.43</version>
+        <version>3.50</version>
     </parent>
 
     <artifactId>external-workspace-manager</artifactId>
@@ -13,7 +13,7 @@
     <packaging>hpi</packaging>
 
     <properties>
-        <jenkins.version>2.138.1</jenkins.version>
+        <jenkins.version>2.138.4</jenkins.version>
         <java.level>8</java.level>
         <argLine>-Xmx1024m</argLine>
     </properties>
@@ -57,22 +57,48 @@
         </pluginRepository>
     </pluginRepositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.138.x</artifactId>
+                <version>3</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.3</version>
-        </dependency>
-        <dependency>
-            <groupId>com.synopsys.arc.jenkinsci.plugins</groupId>
-            <artifactId>job-restrictions</artifactId>
-            <version>0.8</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.2</version>
             <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-basic-steps</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -88,29 +114,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-job</artifactId>
-            <version>2.5</version>
-            <scope>test</scope>
+            <groupId>com.synopsys.arc.jenkinsci.plugins</groupId>
+            <artifactId>job-restrictions</artifactId>
+            <version>0.8</version>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-cps</artifactId>
-            <version>2.11</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-basic-steps</artifactId>
-            <version>2.1</version>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -143,4 +151,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
 </project>

--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsExecution.java
@@ -24,6 +24,7 @@ import org.jenkinsci.plugins.workflow.steps.BodyExecution;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.jenkinsci.plugins.workflow.support.steps.FilePathDynamicContext;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -102,7 +103,7 @@ public class ExwsExecution extends AbstractStepExecutionImpl {
 
         listener.getLogger().println("Running in " + workspace);
         body = getContext().newBodyInvoker()
-                .withContext(workspace)
+                .withContext(FilePathDynamicContext.createContextualObject(workspace))
                 .withCallback(BodyExecutionCallback.wrap(getContext()))
                 .start();
         return false;


### PR DESCRIPTION
This fixes the issue reported in the [mailing list](https://groups.google.com/forum/#!topic/jenkinsci-dev/TXBLRt5ZxjI), related to the change made in Jenkins 2.150.x where workspaces need to be wrapped in `FileDynamicPathContext` (see [this example](https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/101/files#diff-08a6dd4e3141d4c4e0c00e1e80734e19)).

Summary of this pull request:
- [x] Upgrade the pom to use the BOM
- [x] Provide unit test
- [x] Provide fix by using [FileDynamicPathContext](src/main/java/org/jenkinsci/plugins/workflow/support/steps/FilePathDynamicContext.java)

CC @oleg-nenashev @alexsomai 
