### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/ewm/facets/WorkspaceBrowserFacet/main.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ewm/facets/WorkspaceBrowserFacet/main.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-    <l:task icon="images/24x24/folder.png" href="${it.workspace.browseUrl}" title="${%Workspace}"/>
+    <l:task icon="icon-folder icon-md" href="${it.workspace.browseUrl}" title="${%Workspace}"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/ewm/model/ExternalWorkspace/main.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ewm/model/ExternalWorkspace/main.jelly
@@ -14,6 +14,6 @@
         ${%Complete workspace path on} ${it.diskId}
         (${%from Jenkins master}): ${it.completeWorkspacePath}
     </p>
-    <l:task icon="images/24x24/fingerprint.png" href="${rootURL}/fingerprint/${it.id}/" title="${%Fingerprints}"/>
-    <l:task icon="images/24x24/folder.png" href="${it.browseUrl}" title="${%Workspace}"/>
+    <l:task icon="icon-fingerprint icon-md" href="${rootURL}/fingerprint/${it.id}/" title="${%Fingerprints}"/>
+    <l:task icon="icon-folder icon-md" href="${it.browseUrl}" title="${%Workspace}"/>
 </j:jelly>


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @alexsomai 
Thanks in advance!