### PR TITLE
Refresh project metadata and README badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.2 - 2026-06-16
+### Changed
+ - Documentation and project metadata refresh
+
 ## 1.3.1 - 2023-03-12
 ### Fixed
  - Fix `nodeMountPoint` help file name [#78](https://github.com/jenkinsci/external-workspace-manager-plugin/pull/78)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Join the chat at https://gitter.im/jenkinsci/external-workspace-manager-plugin](https://badges.gitter.im/jenkinsci/external-workspace-manager-plugin.svg)](https://gitter.im/jenkinsci/external-workspace-manager-plugin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/external-workspace-manager-plugin/master)](https://ci.jenkins.io/job/Plugins/job/external-workspace-manager-plugin/job/master/)
+[![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/external-workspace-manager.svg)](https://plugins.jenkins.io/external-workspace-manager)
+[![Installs](https://img.shields.io/jenkins/plugin/i/external-workspace-manager.svg?color=blue)](https://stats.jenkins.io/pluginversions/external-workspace-manager.html)
 
 This plugin provides an external workspace management system.
 It facilitates workspace share and reuse across multiple Jenkins jobs.

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     </properties>
 
     <name>External Workspace Manager Plugin</name>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/External+Workspace+Manager+Plugin</url>
+    <url>https://github.com/jenkinsci/external-workspace-manager-plugin</url>
 
     <licenses>
         <license>


### PR DESCRIPTION
Small, low-risk metadata/docs refresh — no build or runtime code touched.

### Changes
- **pom.xml**: replace the dead project URL (decommissioned Jenkins Confluence wiki) with the GitHub repo.
- **README.md**: add plugin version and install-count badges (Gitter chat and ci.jenkins.io build badges unchanged).
- **CHANGELOG.md**: add the `1.3.2` entry.

### Why
The plugin hasn't had a release since March 2023. This is a deliberately tiny change to verify the release pipeline end-to-end before the next functional release.