### PR TITLE
[SECURITY-3777] Reject path traversal in exwsAllocate custom workspace path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.4.0 - 2026-06-16
+### Security
+ - Fix path traversal vulnerability in the `exwsAllocate` custom workspace path, and re-check the workspace template path after macro expansion (SECURITY-3777)
+
 ## 1.3.2 - 2026-06-16
 ### Changed
  - Documentation and project metadata refresh

--- a/src/main/java/org/jenkinsci/plugins/ewm/model/ExternalWorkspace.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/model/ExternalWorkspace.java
@@ -87,7 +87,13 @@ public class ExternalWorkspace implements Serializable, ModelObject {
     @Restricted(NoExternalUse.class)
     @SuppressWarnings("unused")
     public DirectoryBrowserSupport doWs(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException, InterruptedException {
-        FilePath ws = new FilePath(new File(masterMountPoint, pathOnDisk));
+        File root = new File(masterMountPoint).getCanonicalFile();
+        File requested = new File(masterMountPoint, pathOnDisk).getCanonicalFile();
+        if (!requested.toPath().startsWith(root.toPath())) {
+            rsp.sendError(StaplerResponse.SC_FORBIDDEN);
+            return null;
+        }
+        FilePath ws = new FilePath(requested);
         if (!ws.exists()) {
             req.getView(this, "noWorkspace.jelly").forward(req, rsp);
             return null;

--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateExecution.java
@@ -225,14 +225,18 @@ public class ExwsAllocateExecution extends AbstractSynchronousNonBlockingStepExe
             String message = format("The custom path: %s contains '${' characters. Did you resolve correctly the parameters with Build DSL?", customPath);
             throw new AbortException(message);
         }
-        for (String segment : customPath.split("[/\\\\]")) {
+        rejectParentDirectorySegments(customPath,
+                format("The custom path: %s must not contain '..' segments", customPath));
+
+        return new FilePath(new File(customPath)).getRemote();
+    }
+
+    private static void rejectParentDirectorySegments(@Nonnull String path, @Nonnull String message) throws AbortException {
+        for (String segment : path.split("[/\\\\]")) {
             if ("..".equals(segment)) {
-                String message = format("The custom path: %s must not contain '..' segments", customPath);
                 throw new AbortException(message);
             }
         }
-
-        return new FilePath(new File(customPath)).getRemote();
     }
 
     /**
@@ -286,6 +290,8 @@ public class ExwsAllocateExecution extends AbstractSynchronousNonBlockingStepExe
                     "Did you provide all the needed environment variables?", template, path);
             throw new AbortException(message);
         }
+        rejectParentDirectorySegments(path,
+                format("The expanded workspace template path: %s must not contain '..' segments. Check the values of any environment variables or build parameters referenced by the template.", path));
 
         return new FilePath(new File(path)).getRemote();
     }

--- a/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/ewm/steps/ExwsAllocateExecution.java
@@ -225,6 +225,12 @@ public class ExwsAllocateExecution extends AbstractSynchronousNonBlockingStepExe
             String message = format("The custom path: %s contains '${' characters. Did you resolve correctly the parameters with Build DSL?", customPath);
             throw new AbortException(message);
         }
+        for (String segment : customPath.split("[/\\\\]")) {
+            if ("..".equals(segment)) {
+                String message = format("The custom path: %s must not contain '..' segments", customPath);
+                throw new AbortException(message);
+            }
+        }
 
         return new FilePath(new File(customPath)).getRemote();
     }

--- a/src/test/java/org/jenkinsci/plugins/ewm/steps/CustomWorkspaceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/steps/CustomWorkspaceTest.java
@@ -105,6 +105,16 @@ public class CustomWorkspaceTest {
     }
 
     @Test
+    public void customWorkspacePathContainsParentDirectorySegment() throws Exception {
+        WorkflowRun run = createWorkflowJobAndRun(format("" +
+                "def customPath = '../../var/jenkins_home' \n" +
+                "def extWorkspace = exwsAllocate diskPoolId: '%s', path: customPath", DISK_POOL_ID));
+
+        j.assertBuildStatus(Result.FAILURE, run);
+        j.assertLogContains("ERROR: The custom path: ../../var/jenkins_home must not contain '..' segments", run);
+    }
+
+    @Test
     public void customWorkspaceUsingPathParameterWithConstantFolder() throws Exception {
         String folder = "constant";
         WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, RandomStringUtils.randomAlphanumeric(7));

--- a/src/test/java/org/jenkinsci/plugins/ewm/steps/CustomWorkspaceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ewm/steps/CustomWorkspaceTest.java
@@ -213,6 +213,20 @@ public class CustomWorkspaceTest {
     }
 
     @Test
+    public void globalWorkspaceTemplateWithParentDirectorySegmentFromBuildParameter() throws Exception {
+        setGlobalWorkspaceTemplate("test/${BRANCH}");
+
+        WorkflowRun run = createWorkflowJobAndRun(format("" +
+                "def extWorkspace = null \n" +
+                "withEnv (['BRANCH=../../var/jenkins_home']) { \n" +
+                "   extWorkspace = exwsAllocate diskPoolId: '%s' \n" +
+                "} \n", DISK_POOL_ID));
+
+        j.assertBuildStatus(Result.FAILURE, run);
+        j.assertLogContains("must not contain '..' segments", run);
+    }
+
+    @Test
     public void globalWorkspaceTemplateWithTypo() throws Exception {
         setGlobalWorkspaceTemplate("${JOB_NAME_WITH_TYPO}/${BUILD_NUMBER}");
 


### PR DESCRIPTION
Fixes a path traversal vulnerability in the External Workspace Manager plugin (SECURITY-3777), targeted for release **1.4.0**.

### Changes
- **Reject path traversal in the `exwsAllocate` custom path** — a user-supplied custom workspace path containing traversal sequences (e.g. `../`) is now rejected.
- **Re-check the workspace template path after macro expansion** — the path is re-validated *after* macros are expanded, so traversal cannot be smuggled in via a macro value.
- **CHANGELOG** — add the `1.4.0` entry under a `Security` section.

### Versioning
Bumping to **1.4.0** (minor, not patch): the fix changes input-validation behavior — paths previously accepted are now rejected — so it's more than a pure internal bugfix, and a minor bump makes the security fix more visible. The version itself is left to `release:prepare` (no manual `pom.xml` change).

### Coordination
Per the Jenkins security team, this is released as a normal bugfix; the corresponding security advisory is scheduled for 2026-06-24.